### PR TITLE
Refactor apt_mirror configs and rename playbooks

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,0 +1,1 @@
+deployment_profile: "simple"

--- a/group_vars/mirror.yml
+++ b/group_vars/mirror.yml
@@ -1,0 +1,32 @@
+apt_mirror_base_path: "/var/spool/apt-mirror"
+
+apt_mirror_mirrors:
+  - name: "ubuntu_official"
+    base_url: "http://archive.ubuntu.com/ubuntu"
+    distributions:
+      - "focal"
+      - "focal-security"
+      - "focal-updates"
+    components: ["main", "restricted", "universe", "multiverse"]
+  - name: "debian_official"
+    base_url: "http://deb.debian.org/debian"
+    distributions:
+      - "bullseye"
+      - "bullseye-updates"
+    components: ["main"]
+  - name: "debian_security"
+    base_url: "http://security.debian.org/debian-security"
+    distributions:
+      - "bullseye-security"
+    components: ["main"]
+
+apt_mirror_architectures: ["amd64"]
+apt_mirror_include_sources: false
+
+apt_mirror_cron_enabled: true
+apt_mirror_cron_schedule: "0 4 * * *"   # daily 04:00
+
+elk_integration_enabled: false
+ha_features_enabled: false
+dr_backup_enabled: true
+apt_mirror_prune: true

--- a/playbooks/deploy_apt_mirror_complex.yml
+++ b/playbooks/deploy_apt_mirror_complex.yml
@@ -1,0 +1,8 @@
+---
+- name: Complex apt-mirror deployment (production)
+  hosts: mirror
+  become: true
+  vars:
+    deployment_profile: "complex"
+  roles:
+    - apt_mirror

--- a/playbooks/deploy_apt_mirror_simple.yml
+++ b/playbooks/deploy_apt_mirror_simple.yml
@@ -1,0 +1,8 @@
+---
+- name: Simple apt-mirror deployment (dev / test)
+  hosts: mirror
+  become: true
+  vars:
+    deployment_profile: "simple"
+  roles:
+    - apt_mirror

--- a/roles/apt_mirror/README.md
+++ b/roles/apt_mirror/README.md
@@ -1,0 +1,23 @@
+# apt_mirror Ansible Role
+
+Modular, idempotent role for hosting a Debian/Ubuntu `apt-mirror`
+served over Apache HTTP. Supports:
+
+* Multiple distributions / components / architectures  
+* Scheduled sync via cron  
+* Automatic pruning (`clean` lines)  
+* Optional ELK shipping, DR backups, HA stubs  
+* Simple vs. Complex deployment via `deployment_profile`  
+
+## Quick Start
+
+```bash
+ansible-playbook playbooks/deploy_apt_mirror_simple.yml  # dev/test
+ansible-playbook playbooks/deploy_apt_mirror_complex.yml # prod
+```
+
+## Variables
+
+See `defaults/main.yml` and `group_vars/mirror.yml` for full list.
+
+---

--- a/roles/apt_mirror/defaults/main.yml
+++ b/roles/apt_mirror/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# sane defaults – usually overridden in inventory / playbook
+apt_mirror_base_path: "/var/spool/apt-mirror"
+
+apt_mirror_mirrors: []
+apt_mirror_architectures: ["amd64"]
+apt_mirror_include_sources: false
+
+apt_mirror_cron_enabled: true
+apt_mirror_cron_schedule: "0 4 * * *"
+
+elk_integration_enabled: false
+ha_features_enabled: false
+dr_backup_enabled: true
+apt_mirror_prune: true

--- a/roles/apt_mirror/handlers/main.yml
+++ b/roles/apt_mirror/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart apache
+  service:
+    name: apache2
+    state: restarted

--- a/roles/apt_mirror/meta/main.yml
+++ b/roles/apt_mirror/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: apt_mirror
+  author: your_name
+  description: "Modular apt-mirror with Apache, cron, optional ELK/HA/DR."
+  license: MIT
+  min_ansible_version: "2.13"
+  platforms:
+    - name: Debian
+      versions: ["bullseye", "bookworm"]
+    - name: Ubuntu
+      versions: ["focal", "jammy"]
+dependencies: []

--- a/roles/apt_mirror/tasks/apache.yml
+++ b/roles/apt_mirror/tasks/apache.yml
@@ -1,0 +1,29 @@
+---
+- name: Ensure apache modules enabled
+  apache2_module:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - alias
+    - autoindex
+
+- name: Template apache config for apt-mirror
+  template:
+    src: apache-apt-mirror.conf.j2
+    dest: /etc/apache2/conf-available/apt-mirror.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: restart apache
+
+- name: Enable configuration
+  command: a2enconf apt-mirror
+  args:
+    creates: /etc/apache2/conf-enabled/apt-mirror.conf
+  notify: restart apache
+
+- name: Ensure apache started / enabled
+  service:
+    name: apache2
+    state: started
+    enabled: true

--- a/roles/apt_mirror/tasks/configure.yml
+++ b/roles/apt_mirror/tasks/configure.yml
@@ -1,0 +1,16 @@
+---
+- name: Template /etc/apt/mirror.list
+  template:
+    src: mirror.list.j2
+    dest: /etc/apt/mirror.list
+    owner: root
+    group: root
+    mode: "0644"
+  notify: run initial mirror
+
+- name: Create architecture symlink (multi-arch only)
+  file:
+    src: "{{ apt_mirror_base_path }}/mirror"
+    dest: "{{ apt_mirror_base_path }}/mirror_arch"
+    state: link
+  when: apt_mirror_multi_arch | bool

--- a/roles/apt_mirror/tasks/cron.yml
+++ b/roles/apt_mirror/tasks/cron.yml
@@ -1,0 +1,12 @@
+---
+- name: Schedule apt-mirror sync
+  cron:
+    name: "apt-mirror sync"
+    user: "apt-mirror"
+    job: "/usr/bin/apt-mirror > {{ apt_mirror_base_path }}/var/cron.log 2>&1"
+    state: present
+    minute: "{{ apt_mirror_cron_schedule.split(' ')[0] }}"
+    hour:   "{{ apt_mirror_cron_schedule.split(' ')[1] }}"
+    day:    "{{ apt_mirror_cron_schedule.split(' ')[2] }}"
+    month:  "{{ apt_mirror_cron_schedule.split(' ')[3] }}"
+    weekday:"{{ apt_mirror_cron_schedule.split(' ')[4] }}"

--- a/roles/apt_mirror/tasks/dr_backup.yml
+++ b/roles/apt_mirror/tasks/dr_backup.yml
@@ -1,0 +1,21 @@
+---
+- name: Create backup directory
+  file:
+    path: /var/backups/apt-mirror
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Weekly tar backup of mirror index (lightweight)
+  cron:
+    name: "Backup apt-mirror metadata"
+    user: root
+    job: >
+      tar -czf /var/backups/apt-mirror/metadata_$(date +\%F).tgz
+      {{ apt_mirror_base_path }}/var
+    weekday: 0
+    hour: 2
+    minute: 0
+    state: present
+  when: dr_backup_enabled | bool

--- a/roles/apt_mirror/tasks/elk.yml
+++ b/roles/apt_mirror/tasks/elk.yml
@@ -1,0 +1,18 @@
+---
+- name: Install filebeat (placeholder – implement as needed)
+  apt:
+    name: filebeat
+    state: present
+
+- name: Configure filebeat for apt-mirror logs (placeholder)
+  lineinfile:
+    path: /etc/filebeat/filebeat.yml
+    regexp: '^ *- /var/spool/apt-mirror/var/cron.log'
+    line: "  - /var/spool/apt-mirror/var/cron.log"
+  notify: restart filebeat
+
+- name: Ensure filebeat service
+  service:
+    name: filebeat
+    state: started
+    enabled: true

--- a/roles/apt_mirror/tasks/ha.yml
+++ b/roles/apt_mirror/tasks/ha.yml
@@ -1,0 +1,4 @@
+---
+# placeholder for HA; currently no-op
+- debug:
+    msg: "HA features not implemented for single-instance deployment."

--- a/roles/apt_mirror/tasks/install.yml
+++ b/roles/apt_mirror/tasks/install.yml
@@ -1,0 +1,17 @@
+---
+- name: Install apt-mirror and dependencies
+  apt:
+    name:
+      - apt-mirror
+      - apache2
+      - python3-apt
+    state: present
+    update_cache: true
+
+- name: Ensure base path exists
+  file:
+    path: "{{ apt_mirror_base_path }}"
+    state: directory
+    owner: apt-mirror
+    group: apt-mirror
+    mode: "0755"

--- a/roles/apt_mirror/tasks/main.yml
+++ b/roles/apt_mirror/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- import_tasks: install.yml
+- import_tasks: configure.yml
+- import_tasks: apache.yml
+- import_tasks: cron.yml
+  when: apt_mirror_cron_enabled | bool
+- import_tasks: elk.yml
+  when: elk_integration_enabled | bool
+- import_tasks: ha.yml
+  when: ha_features_enabled | bool
+- import_tasks: dr_backup.yml
+  when: dr_backup_enabled | bool
+- import_tasks: prune.yml
+  when: apt_mirror_prune | bool

--- a/roles/apt_mirror/tasks/prune.yml
+++ b/roles/apt_mirror/tasks/prune.yml
@@ -1,0 +1,6 @@
+---
+- name: Run clean.sh after sync
+  shell: "{{ apt_mirror_base_path }}/var/clean.sh"
+  args:
+    executable: /bin/bash
+  when: apt_mirror_prune | bool

--- a/roles/apt_mirror/templates/apache-apt-mirror.conf.j2
+++ b/roles/apt_mirror/templates/apache-apt-mirror.conf.j2
@@ -1,0 +1,13 @@
+# Apache configuration to serve apt-mirror repositories
+Alias /mirror/ "{{ apt_mirror_base_path }}/mirror/"
+
+<Directory "{{ apt_mirror_base_path }}/mirror/">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>
+
+# Convenience aliases based on mirror names
+{% for mirror in apt_mirror_mirrors %}
+Alias /{{ mirror.name }}/ "{{ apt_mirror_base_path }}/mirror/{{ mirror.base_url | regex_replace('https?://','') }}/"
+{% endfor %}

--- a/roles/apt_mirror/templates/mirror.list.j2
+++ b/roles/apt_mirror/templates/mirror.list.j2
@@ -1,0 +1,15 @@
+set base_path    {{ apt_mirror_base_path }}
+set nthreads     20
+set _tilde       0
+
+{% for mirror in apt_mirror_mirrors %}
+{% for distro in mirror.distributions %}
+{% for arch in apt_mirror_architectures %}
+deb-{{ arch }} {{ mirror.base_url }} {{ distro }} {{ mirror.components | join(' ') }}
+{% if apt_mirror_source_pkgs %}
+deb-src {{ mirror.base_url }} {{ distro }} {{ mirror.components | join(' ') }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+clean {{ mirror.base_url }}
+{% endfor %}

--- a/roles/apt_mirror/vars/main.yml
+++ b/roles/apt_mirror/vars/main.yml
@@ -1,0 +1,11 @@
+---
+# derive feature flags from deployment_profile
+apt_mirror_multi_arch: "{{ (deployment_profile | default('simple')) == 'complex' or apt_mirror_architectures | length > 1 }}"
+apt_mirror_source_pkgs: "{{ (deployment_profile | default('simple')) == 'complex' or apt_mirror_include_sources }}"
+
+elk_integration_enabled: "{{ (deployment_profile | default('simple')) == 'complex' or elk_integration_enabled }}"
+ha_features_enabled: "{{ (deployment_profile | default('simple')) == 'complex' and ha_features_enabled }}"
+dr_backup_enabled: "{{ dr_backup_enabled }}"
+
+# cron always on unless explicitly disabled
+apt_mirror_cron_enabled: "{{ apt_mirror_cron_enabled }}"

--- a/src/apt_mirror.yml
+++ b/src/apt_mirror.yml
@@ -3,7 +3,7 @@
   become: yes
   vars_files:
     - group_vars/all.yml
-    - group_vars/apt_mirror.yml
+    - group_vars/mirror.yml
   roles:
     - base
 
@@ -11,7 +11,7 @@
   become: yes
   vars_files:
     - group_vars/all.yml
-    - group_vars/apt_mirror.yml
+    - group_vars/mirror.yml
   roles:
     - mrlesmithjr.apache2
     - mrlesmithjr.apt-mirror
@@ -21,7 +21,7 @@
   become: yes
   vars_files:
     - group_vars/all.yml
-    - group_vars/apt_mirror.yml
+    - group_vars/mirror.yml
   tasks:
     - name: install gnupg2
       apt:
@@ -41,6 +41,6 @@
   become: yes
   vars_files:
     - group_vars/all.yml
-    - group_vars/apt_mirror.yml
+    - group_vars/mirror.yml
   roles:
     - mrlesmithjr.nginx-load-balancer


### PR DESCRIPTION
## Summary
- split apt-mirror settings into `group_vars/mirror.yml`
- keep only `deployment_profile` in `group_vars/all.yml`
- rename deployment playbooks to `deploy_apt_mirror_*`
- update README and example playbook paths

## Testing
- `ansible-playbook playbooks/deploy_apt_mirror_simple.yml --syntax-check` *(fails: command not found)*
- `ansible-playbook playbooks/deploy_apt_mirror_complex.yml --syntax-check` *(fails: command not found)*
