### PR TITLE
Add step_ca role and related configs

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+roles_path = ./roles
+retry_files_enabled = False
+pipelining = True
+forks = 20

--- a/inventories/dev/group_vars/step_ca_servers.yml
+++ b/inventories/dev/group_vars/step_ca_servers.yml
@@ -1,0 +1,7 @@
+step_ca_version: "0.25.1"
+step_ca_use_vault_ra: false
+step_ca_db_backend: "badger"
+step_ca_dns_names:
+  - "ca-dev.local"
+step_ca_listen_address: ":8443"
+step_ca_bootstrap: true

--- a/inventories/dev/hosts.ini
+++ b/inventories/dev/hosts.ini
@@ -1,0 +1,2 @@
+[step_ca_servers]
+ca-dev.local ansible_host=192.168.1.100

--- a/inventories/prod/group_vars/step_ca_servers.yml
+++ b/inventories/prod/group_vars/step_ca_servers.yml
@@ -1,0 +1,15 @@
+step_ca_version: "0.25.1"
+step_ca_use_vault_ra: true
+step_ca_db_backend: "mysql"
+step_ca_db_host: "ca-db.prod.example.com"
+step_ca_db_name: "stepca"
+step_ca_db_username: "stepca_user"
+step_ca_db_password: "{{ lookup('community.hashi_vault.vault', 'secret=db/stepca username=stepca_user field=password token='+vault_token) }}"
+step_ca_vault_address: "https://vault.prod.example.com:8200"
+step_ca_vault_pki_mount: "pki_int1"
+step_ca_vault_role_id: "{{ lookup('community.hashi_vault.vault', 'secret=stepca/approle field=role_id token='+vault_token) }}"
+step_ca_vault_secret_id: "{{ lookup('community.hashi_vault.vault', 'secret=stepca/approle/secret-id field=secret_id token='+vault_token) }}"
+step_ca_vault_cacert: "/etc/ssl/certs/vault_ca.crt"
+step_ca_dns_names:
+  - "ca.prod.example.com"
+step_ca_listen_address: ":443"

--- a/inventories/prod/hosts.ini
+++ b/inventories/prod/hosts.ini
@@ -1,0 +1,7 @@
+[step_ca_servers]
+ca1.prod.example.com ansible_host=10.0.0.10 step_ca_primary=true
+ca2.prod.example.com ansible_host=10.0.1.11
+ca3.prod.example.com ansible_host=10.0.2.12
+
+[mysql_servers]
+ca-db.prod.example.com ansible_host=10.0.0.20

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: stepca
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ../../playbooks/deploy_step_ca.yml
+verifier:
+  name: ansible

--- a/playbooks/deploy_step_ca.yml
+++ b/playbooks/deploy_step_ca.yml
@@ -1,0 +1,5 @@
+- name: Deploy Step CA (single node)
+  hosts: step_ca_servers
+  become: true
+  roles:
+    - step_ca

--- a/playbooks/deploy_step_ca_cluster.yml
+++ b/playbooks/deploy_step_ca_cluster.yml
@@ -1,0 +1,7 @@
+- name: Deploy Step CA cluster
+  hosts: step_ca_servers
+  become: true
+  vars:
+    step_ca_bootstrap: "{{ (step_ca_primary | default(false) | bool) }}"
+  roles:
+    - step_ca

--- a/roles/step_ca/README.md
+++ b/roles/step_ca/README.md
@@ -1,0 +1,1 @@
+# Ansible Role: step_ca

--- a/roles/step_ca/defaults/main.yml
+++ b/roles/step_ca/defaults/main.yml
@@ -1,0 +1,20 @@
+step_ca_version: "latest"
+step_cli_version: "latest"
+step_ca_user: "step"
+step_ca_group: "step"
+step_ca_home: "/home/step"
+step_ca_config_path: "{{ step_ca_home }}/.step/config"
+step_ca_listen_address: ":8443"
+step_ca_dns_names: []
+step_ca_use_vault_ra: false
+step_ca_vault_address: ""
+step_ca_vault_pki_mount: ""
+step_ca_vault_role_id: ""
+step_ca_vault_secret_id: ""
+step_ca_vault_cacert: "/etc/ssl/certs/ca-certificates.crt"
+step_ca_db_backend: "badger"
+step_ca_db_host: ""
+step_ca_db_name: ""
+step_ca_db_username: ""
+step_ca_db_password: ""
+step_ca_bootstrap: false

--- a/roles/step_ca/handlers/main.yml
+++ b/roles/step_ca/handlers/main.yml
@@ -1,0 +1,7 @@
+- name: Reload systemd
+  command: systemctl daemon-reload
+
+- name: Restart step-ca
+  service:
+    name: step-ca
+    state: restarted

--- a/roles/step_ca/meta/main.yml
+++ b/roles/step_ca/meta/main.yml
@@ -1,0 +1,8 @@
+galaxy_info:
+  author: your_name
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions: [bullseye, bookworm]
+  license: MIT
+dependencies: []

--- a/roles/step_ca/tasks/bootstrap.yml
+++ b/roles/step_ca/tasks/bootstrap.yml
@@ -1,0 +1,21 @@
+- name: Ensure step user exists
+  user:
+    name: "{{ step_ca_user }}"
+    group: "{{ step_ca_group }}"
+    shell: /usr/sbin/nologin
+    create_home: yes
+
+- name: Initialize step-ca
+  become_user: "{{ step_ca_user }}"
+  command: >
+    step ca init
+    --non-interactive
+    --name "Internal CA"
+    --dns "{{ step_ca_dns_names | join(',') }}"
+    --address "{{ step_ca_listen_address }}"
+    --provisioner "admin"
+    --password-file "{{ step_ca_home }}/ca-pass.txt"
+  args:
+    creates: "{{ step_ca_config_path }}/ca.json"
+  when: step_ca_use_vault_ra | bool == false
+  notify: Restart step-ca

--- a/roles/step_ca/tasks/config.yml
+++ b/roles/step_ca/tasks/config.yml
@@ -1,0 +1,25 @@
+- name: Create config directory
+  file:
+    path: "{{ step_ca_config_path }}"
+    owner: "{{ step_ca_user }}"
+    group: "{{ step_ca_group }}"
+    mode: '0750'
+    state: directory
+
+- name: Template ca.json
+  template:
+    src: ca.json.j2
+    dest: "{{ step_ca_config_path }}/ca.json"
+    owner: "{{ step_ca_user }}"
+    group: "{{ step_ca_group }}"
+    mode: '0600'
+  notify: Restart step-ca
+
+- name: Template step-ca systemd unit
+  template:
+    src: step-ca.service.j2
+    dest: /etc/systemd/system/step-ca.service
+    mode: '0644'
+  notify:
+    - Reload systemd
+    - Restart step-ca

--- a/roles/step_ca/tasks/install.yml
+++ b/roles/step_ca/tasks/install.yml
@@ -1,0 +1,17 @@
+- name: Add Smallstep APT key
+  apt_key:
+    url: https://dl.smallstep.com/apt/keys/steps-public-key.asc
+    state: present
+
+- name: Add Smallstep repository
+  apt_repository:
+    repo: "deb [arch=amd64] https://dl.smallstep.com/apt {{ ansible_distribution_release }} main"
+    state: present
+
+- name: Install step and step-ca packages
+  apt:
+    name:
+      - "step={{ step_cli_version if step_cli_version != 'latest' else '' }}"
+      - "step-ca={{ step_ca_version if step_ca_version != 'latest' else '' }}"
+    state: present
+    update_cache: yes

--- a/roles/step_ca/tasks/main.yml
+++ b/roles/step_ca/tasks/main.yml
@@ -1,0 +1,12 @@
+- name: Include install tasks
+  import_tasks: install.yml
+
+- name: Include bootstrap tasks
+  import_tasks: bootstrap.yml
+  when: step_ca_bootstrap | bool
+
+- name: Include config tasks
+  import_tasks: config.yml
+
+- name: Include service tasks
+  import_tasks: service.yml

--- a/roles/step_ca/tasks/service.yml
+++ b/roles/step_ca/tasks/service.yml
@@ -1,0 +1,5 @@
+- name: Enable and start step-ca
+  service:
+    name: step-ca
+    enabled: yes
+    state: started

--- a/roles/step_ca/templates/ca.json.j2
+++ b/roles/step_ca/templates/ca.json.j2
@@ -1,0 +1,28 @@
+{
+  "address": "{{ step_ca_listen_address }}",
+  "dnsNames": {{ step_ca_dns_names | to_json }},
+  {% if step_ca_use_vault_ra %}
+  "authority": {
+    "type": "vaultCAS",
+    "certificateAuthority": "{{ step_ca_vault_address }}",
+    "certificateAuthorityFingerprint": "",
+    "provisioners": [],
+    "config": {
+      "pkiMountPath": "{{ step_ca_vault_pki_mount }}"
+    },
+    "authType": "approle",
+    "authOptions": {
+      "roleId": "{{ step_ca_vault_role_id }}",
+      "secretId": "{{ step_ca_vault_secret_id }}",
+      "secretIdFile": "",
+      "namespace": ""
+    }
+  },
+  {% else %}
+  "authority": {},
+  {% endif %}
+  "db": {
+    "type": "{{ step_ca_db_backend }}"{% if step_ca_db_backend != 'badger' %},
+    "dataSource": "{{ step_ca_db_username }}:{{ step_ca_db_password }}@tcp({{ step_ca_db_host }}:3306)/{{ step_ca_db_name }}"{% endif %}
+  }
+}

--- a/roles/step_ca/templates/step-ca.service.j2
+++ b/roles/step_ca/templates/step-ca.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=step-ca certificate authority
+After=network.target
+
+[Service]
+User={{ step_ca_user }}
+Group={{ step_ca_group }}
+ExecStart=/usr/bin/step-ca {{ step_ca_config_path }}/ca.json --password-file {{ step_ca_home }}/ca-pass.txt
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+Environment="STEPPATH={{ step_ca_home }}/.step"
+{% if step_ca_use_vault_ra %}
+Environment="VAULT_CACERT={{ step_ca_vault_cacert }}"
+{% endif %}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add ansible.cfg
- create dev and prod inventories for step_ca
- add deployment playbooks
- implement step_ca role with defaults, handlers, tasks, and templates
- add molecule scenario

## Testing
- `ansible-playbook --syntax-check playbooks/deploy_step_ca.yml` *(fails: command not found)*