### PR TITLE
Add GoDaddy-based Let's Encrypt role

### DIFF
--- a/src/roles/letsencrypt_godaddy/defaults/main.yml
+++ b/src/roles/letsencrypt_godaddy/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+cert_domains: []
+letsencrypt_account_email: ""
+godaddy_api_key: ""
+godaddy_api_secret: ""
+cert_install_path: "/etc/letsencrypt/live"
+service_reload_command: ""
+use_staging: false
+propagation_wait: 600
+acme_sh_install_dir: "/etc/acme"
+acme_sh_git_url: "https://github.com/acmesh-official/acme.sh"
+acme_install_cron: true
+force_renew: false
+acme_sh_auto_upgrade: false

--- a/src/roles/letsencrypt_godaddy/handlers/main.yml
+++ b/src/roles/letsencrypt_godaddy/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: reload_service
+  ansible.builtin.shell: "{{ service_reload_command }}"
+  when: service_reload_command | length > 0
+  become: true

--- a/src/roles/letsencrypt_godaddy/meta/main.yml
+++ b/src/roles/letsencrypt_godaddy/meta/main.yml
@@ -1,0 +1,11 @@
+---
+galaxy_info:
+  role_name: letsencrypt_godaddy
+  author: yourname
+  description: Obtain and renew Let's Encrypt certificates using GoDaddy DNS API via acme.sh
+  license: MIT
+  platforms:
+    - name: Debian
+      versions: all
+  min_ansible_version: "2.14"
+dependencies: []

--- a/src/roles/letsencrypt_godaddy/molecule/default/converge.yml
+++ b/src/roles/letsencrypt_godaddy/molecule/default/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    cert_domains:
+      - "example.com"
+    godaddy_api_key: "dummy"
+    godaddy_api_secret: "dummy"
+    use_staging: true
+    service_reload_command: "/bin/true"
+  roles:
+    - role: letsencrypt_godaddy

--- a/src/roles/letsencrypt_godaddy/molecule/default/molecule.yml
+++ b/src/roles/letsencrypt_godaddy/molecule/default/molecule.yml
@@ -1,0 +1,14 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: geerlingguy/docker-debian12-ansible
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/src/roles/letsencrypt_godaddy/molecule/default/verify.yml
+++ b/src/roles/letsencrypt_godaddy/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Check acme.sh directory exists
+      ansible.builtin.stat:
+        path: "/etc/acme"
+      register: acme_dir
+    - ansible.builtin.assert:
+        that: acme_dir.stat.exists

--- a/src/roles/letsencrypt_godaddy/tasks/deploy.yml
+++ b/src/roles/letsencrypt_godaddy/tasks/deploy.yml
@@ -1,0 +1,30 @@
+---
+- name: Determine primary domain
+  ansible.builtin.set_fact:
+    primary_domain: "{{ cert_domains[0] }}"
+
+- name: Ensure certificate directory exists
+  ansible.builtin.file:
+    path: "{{ cert_install_path }}/{{ primary_domain }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+
+- name: Install certificate to target path
+  ansible.builtin.shell: |
+    export GD_Key="{{ godaddy_api_key }}";
+    export GD_Secret="{{ godaddy_api_secret }}";
+    "{{ acme_sh_install_dir }}/acme.sh" --install-cert -d "{{ primary_domain }}" \
+      --home "{{ acme_sh_install_dir }}" \
+      --config-home "{{ acme_sh_install_dir }}" \
+      --cert-file "{{ cert_install_path }}/{{ primary_domain }}/cert.pem" \
+      --key-file "{{ cert_install_path }}/{{ primary_domain }}/privkey.pem" \
+      --fullchain-file "{{ cert_install_path }}/{{ primary_domain }}/fullchain.pem" \
+      {% if service_reload_command %}--reloadcmd "{{ service_reload_command }}"{% endif %}
+  register: acme_install
+  changed_when: "'Cert success' in acme_install.stdout or 'Installing' in acme_install.stdout"
+  notify: reload_service
+  no_log: true
+  become: true

--- a/src/roles/letsencrypt_godaddy/tasks/install.yml
+++ b/src/roles/letsencrypt_godaddy/tasks/install.yml
@@ -1,0 +1,29 @@
+---
+- name: Ensure prerequisites
+  ansible.builtin.apt:
+    name:
+      - git
+      - curl
+      - cron
+    state: present
+    update_cache: yes
+  become: true
+
+- name: Clone acme.sh repository
+  ansible.builtin.git:
+    repo: "{{ acme_sh_git_url }}"
+    dest: "{{ acme_sh_install_dir }}"
+    version: master
+    update: yes
+  become: true
+
+- name: Install acme.sh (first run only)
+  ansible.builtin.shell: |
+    "{{ acme_sh_install_dir }}/acme.sh" --install \
+      --home "{{ acme_sh_install_dir }}" \
+      --config-home "{{ acme_sh_install_dir }}" \
+      {% if acme_install_cron %}--accountemail "{{ letsencrypt_account_email | default('') }}" {% else %}--nocron{% endif %} \
+      {% if acme_sh_auto_upgrade %}--auto-upgrade{% else %}--no-upgrade{% endif %}
+  args:
+    creates: "{{ acme_sh_install_dir }}/acme.sh.env"
+  become: true

--- a/src/roles/letsencrypt_godaddy/tasks/main.yml
+++ b/src/roles/letsencrypt_godaddy/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- import_tasks: install.yml
+- import_tasks: obtain.yml
+- import_tasks: deploy.yml

--- a/src/roles/letsencrypt_godaddy/tasks/obtain.yml
+++ b/src/roles/letsencrypt_godaddy/tasks/obtain.yml
@@ -1,0 +1,30 @@
+---
+- name: Fail if domains are not set
+  ansible.builtin.fail:
+    msg: "cert_domains must contain at least one domain"
+  when: cert_domains | length == 0
+
+- name: Set ACME CA flag
+  ansible.builtin.set_fact:
+    acme_ca_flag: "{{ '--staging' if use_staging else '' }}"
+
+- name: Issue or renew certificate
+  ansible.builtin.shell: |
+    export GD_Key="{{ godaddy_api_key }}";
+    export GD_Secret="{{ godaddy_api_secret }}";
+    "{{ acme_sh_install_dir }}/acme.sh" --issue \
+      --dns dns_gd \
+      {% for domain in cert_domains %}-d {{ domain }} {% endfor %} \
+      --dnssleep {{ propagation_wait }} \
+      {{ acme_ca_flag }} \
+      {% if letsencrypt_account_email %}--accountemail "{{ letsencrypt_account_email }}"{% endif %} \
+      {% if force_renew %}--force{% endif %} \
+      --home "{{ acme_sh_install_dir }}" \
+      --config-home "{{ acme_sh_install_dir }}"
+  environment:
+    GD_Key: "{{ godaddy_api_key }}"
+    GD_Secret: "{{ godaddy_api_secret }}"
+  register: acme_issue
+  changed_when: "'Cert success' in acme_issue.stdout or 'Cert success' in acme_issue.stderr"
+  no_log: true
+  become: true


### PR DESCRIPTION
## Summary
- add `letsencrypt_godaddy` role for managing LE certs with GoDaddy DNS
- include handlers, tasks, metadata, defaults, and molecule scenario

## Testing
- `git status --short`