### PR TITLE
Add BIND9 role with inventories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Ansible
 
+This repository contains various Ansible playbooks and roles.
+
+## BIND9 Role
+
+A modular role for managing BIND9 DNS servers is provided under `src/roles/bind9`.
+Use the playbook `src/playbooks/deploy_bind9.yml` with inventories in
+`src/inventories/development` or `src/inventories/production`.

--- a/src/inventories/development/group_vars/dns.yml
+++ b/src/inventories/development/group_vars/dns.yml
@@ -1,0 +1,17 @@
+bind9_forwarders:
+  - 8.8.8.8
+  - 1.1.1.1
+
+bind9_zones:
+  - name: example.com
+    type: master
+    dnssec: true
+    dynamic_updates: true
+    records:
+      - { name: 'host1', type: 'A', value: '192.168.10.50' }
+
+bind9_allow_query:
+  - '192.168.10.0/24'
+
+bind9_logging_enabled: true
+elk_logstash_host: 'elk.example.com'

--- a/src/inventories/development/hosts.yml
+++ b/src/inventories/development/hosts.yml
@@ -1,0 +1,8 @@
+dns_primary:
+  hosts:
+    dns-dev-01:
+      ansible_host: 10.0.1.10
+dns_secondary:
+  hosts:
+    dns-dev-02:
+      ansible_host: 10.0.1.11

--- a/src/inventories/production/group_vars/dns.yml
+++ b/src/inventories/production/group_vars/dns.yml
@@ -1,0 +1,17 @@
+bind9_forwarders:
+  - 8.8.8.8
+  - 1.1.1.1
+
+bind9_zones:
+  - name: example.com
+    type: master
+    dnssec: true
+    dynamic_updates: true
+    records:
+      - { name: 'host1', type: 'A', value: '192.168.10.50' }
+
+bind9_allow_query:
+  - '192.168.10.0/24'
+
+bind9_logging_enabled: true
+elk_logstash_host: 'elk.example.com'

--- a/src/inventories/production/hosts.yml
+++ b/src/inventories/production/hosts.yml
@@ -1,0 +1,10 @@
+dns_primary:
+  hosts:
+    dns-prod-01:
+      ansible_host: 192.168.10.10
+dns_secondary:
+  hosts:
+    dns-prod-02:
+      ansible_host: 192.168.10.11
+    dns-prod-03:
+      ansible_host: 192.168.10.12

--- a/src/playbooks/deploy_bind9.yml
+++ b/src/playbooks/deploy_bind9.yml
@@ -1,0 +1,4 @@
+- hosts: dns_primary:dns_secondary
+  become: yes
+  roles:
+    - bind9

--- a/src/roles/bind9/defaults/main.yml
+++ b/src/roles/bind9/defaults/main.yml
@@ -1,0 +1,4 @@
+bind9_package_name: bind9
+bind9_service_name: bind9
+bind9_log_dir: /var/log/named
+bind9_dnssec_policy: default

--- a/src/roles/bind9/handlers/main.yml
+++ b/src/roles/bind9/handlers/main.yml
@@ -1,0 +1,7 @@
+- name: Restart BIND9
+  service:
+    name: "{{ bind9_service_name }}"
+    state: restarted
+
+- name: Reload BIND9
+  command: rndc reload

--- a/src/roles/bind9/meta/main.yml
+++ b/src/roles/bind9/meta/main.yml
@@ -1,0 +1,11 @@
+---
+galaxy_info:
+  role_name: bind9
+  author: your_name
+  description: Manage BIND9 DNS servers
+  license: MIT
+  min_ansible_version: "2.13"
+  platforms:
+    - name: Debian
+      versions: ["bullseye", "bookworm"]
+dependencies: []

--- a/src/roles/bind9/tasks/configure.yml
+++ b/src/roles/bind9/tasks/configure.yml
@@ -1,0 +1,18 @@
+- name: Deploy named.conf.options
+  template:
+    src: named.conf.options.j2
+    dest: /etc/bind/named.conf.options
+  notify: Restart BIND9
+
+- name: Deploy named.conf.local with zone definitions
+  template:
+    src: named.conf.local.j2
+    dest: /etc/bind/named.conf.local
+  notify: Restart BIND9
+
+- name: Create zone files
+  template:
+    src: zone.db.j2
+    dest: "/etc/bind/db.{{ item.name }}"
+  loop: "{{ bind9_zones }}"
+  notify: Reload BIND9

--- a/src/roles/bind9/tasks/dnssec.yml
+++ b/src/roles/bind9/tasks/dnssec.yml
@@ -1,0 +1,24 @@
+- name: Ensure DNSSEC keys directory exists
+  file:
+    path: /etc/bind/keys
+    state: directory
+    owner: bind
+    group: bind
+    mode: '0750'
+
+- name: Generate DNSSEC keys
+  command: >
+    dnssec-keygen -a RSASHA256 -b 2048 -f KSK
+    -K /etc/bind/keys {{ item.name }}
+  args:
+    creates: "/etc/bind/keys/K{{ item.name }}.*.key"
+  loop: "{{ bind9_zones }}"
+  when: item.dnssec
+
+- name: Include keys in BIND config
+  template:
+    src: key.conf.j2
+    dest: "/etc/bind/keys/{{ item.name }}.key"
+  loop: "{{ bind9_zones }}"
+  when: item.dynamic_updates
+  notify: Reload BIND9

--- a/src/roles/bind9/tasks/install.yml
+++ b/src/roles/bind9/tasks/install.yml
@@ -1,0 +1,5 @@
+- name: Install BIND9 packages
+  apt:
+    name: "{{ bind9_package_name }}"
+    state: present
+    update_cache: yes

--- a/src/roles/bind9/tasks/logging.yml
+++ b/src/roles/bind9/tasks/logging.yml
@@ -1,0 +1,24 @@
+- name: Ensure logging directory exists
+  file:
+    path: "{{ bind9_log_dir }}"
+    state: directory
+    owner: bind
+    group: bind
+    mode: '0755'
+
+- name: Configure log rotation
+  copy:
+    dest: /etc/logrotate.d/bind9
+    content: |
+      {{ bind9_log_dir }}/*.log {
+          weekly
+          missingok
+          rotate 12
+          compress
+          delaycompress
+          notifempty
+          create 644 bind bind
+          postrotate
+              rndc reconfig
+          endscript
+      }

--- a/src/roles/bind9/tasks/main.yml
+++ b/src/roles/bind9/tasks/main.yml
@@ -1,0 +1,4 @@
+- include_tasks: install.yml
+- include_tasks: configure.yml
+- include_tasks: dnssec.yml
+- include_tasks: logging.yml

--- a/src/roles/bind9/templates/key.conf.j2
+++ b/src/roles/bind9/templates/key.conf.j2
@@ -1,0 +1,1 @@
+# Placeholder for DNSSEC key include

--- a/src/roles/bind9/templates/named.conf.local.j2
+++ b/src/roles/bind9/templates/named.conf.local.j2
@@ -1,0 +1,11 @@
+{% for zone in bind9_zones %}
+zone "{{ zone.name }}" {
+    type {{ zone.type }};
+    file "/etc/bind/db.{{ zone.name }}";
+    {% if zone.dynamic_updates %}
+    update-policy {
+      grant rndc-key zonesub ANY;
+    };
+    {% endif %}
+};
+{% endfor %}

--- a/src/roles/bind9/templates/named.conf.options.j2
+++ b/src/roles/bind9/templates/named.conf.options.j2
@@ -1,0 +1,7 @@
+options {
+  directory "/var/cache/bind";
+  recursion yes;
+  allow-query { {{ bind9_allow_query | join("; ") }}; };
+  forwarders { {{ bind9_forwarders | join("; ") }}; };
+  dnssec-validation auto;
+};

--- a/src/roles/bind9/templates/zone.db.j2
+++ b/src/roles/bind9/templates/zone.db.j2
@@ -1,0 +1,12 @@
+$TTL 86400
+@   IN  SOA ns1.{{ item.name }}. admin.{{ item.name }}. (
+          2025051201 ; Serial
+          3600       ; Refresh
+          1800       ; Retry
+          604800     ; Expire
+          86400      ; Minimum
+      )
+@   IN  NS  ns1.{{ item.name }}.
+{% for record in item.records %}
+{{ record.name }}  IN  {{ record.type }}  {{ record.value }}
+{% endfor %}


### PR DESCRIPTION
## Summary
- implement a new `bind9` role with tasks, handlers, defaults and templates
- add example development and production inventories
- add playbook for deploying BIND9
- update README with info about the role

## Testing
- `git status --short`