### PR TITLE
Add HAProxy and Keepalived roles

### DIFF
--- a/src/group_vars/loadbalancers.yml
+++ b/src/group_vars/loadbalancers.yml
@@ -1,0 +1,21 @@
+---
+haproxy_frontend_port: 443
+haproxy_frontend_mode: http
+haproxy_backend_mode: http
+haproxy_backend_balance_method: leastconn
+haproxy_backend_httpchk: "GET /healthz HTTP/1.1\\r\\nHost: health"
+
+haproxy_ssl_certificate: /etc/haproxy/certs/prod_bundle.pem
+haproxy_ssl_certificate_content: "{{ vault_prod_bundle_pem }}"
+
+haproxy_stats_enable: true
+haproxy_stats_user: admin
+haproxy_stats_password: "{{ vault_haproxy_stats_pw }}"
+haproxy_stats_port: 9000
+haproxy_stats_bind_address: 0.0.0.0
+
+keepalived_virtual_ip: 10.0.0.50
+keepalived_virtual_cidr: 32
+keepalived_interface: eth0
+keepalived_router_id: 50
+keepalived_auth_pass: "{{ vault_vrrp_auth_pass }}"

--- a/src/host_vars/haproxy1.yml
+++ b/src/host_vars/haproxy1.yml
@@ -1,0 +1,3 @@
+---
+keepalived_state: MASTER
+keepalived_priority: 150

--- a/src/host_vars/haproxy2.yml
+++ b/src/host_vars/haproxy2.yml
@@ -1,0 +1,3 @@
+---
+keepalived_state: BACKUP
+keepalived_priority: 100

--- a/src/inventories/production.ini
+++ b/src/inventories/production.ini
@@ -1,0 +1,8 @@
+[loadbalancers]
+haproxy1 ansible_host=10.0.0.11
+haproxy2 ansible_host=10.0.0.12
+
+[appservers]
+app1 ansible_host=10.0.1.101
+app2 ansible_host=10.0.1.102
+app3 ansible_host=10.0.1.103

--- a/src/playbooks/haproxy_dev.yml
+++ b/src/playbooks/haproxy_dev.yml
@@ -1,0 +1,6 @@
+---
+- name: Deploy HAProxy (single node dev)
+  hosts: haproxy
+  become: yes
+  roles:
+    - role: haproxy

--- a/src/playbooks/haproxy_prod.yml
+++ b/src/playbooks/haproxy_prod.yml
@@ -1,0 +1,12 @@
+---
+- name: Gather facts from backend servers
+  hosts: appservers
+  gather_facts: yes
+  become: false
+
+- name: Deploy HAProxy cluster with Keepalived
+  hosts: loadbalancers
+  become: yes
+  roles:
+    - role: haproxy
+    - role: keepalived

--- a/src/roles/haproxy/defaults/main.yml
+++ b/src/roles/haproxy/defaults/main.yml
@@ -1,0 +1,39 @@
+---
+haproxy_package_name: haproxy
+haproxy_service_name: haproxy
+
+haproxy_frontend_name: hafrontend
+haproxy_frontend_bind_address: "*"
+haproxy_frontend_port: 80
+haproxy_frontend_mode: "http"
+
+haproxy_backend_name: habackend
+haproxy_backend_mode: "{{ haproxy_frontend_mode }}"
+haproxy_backend_balance_method: "roundrobin"
+haproxy_backend_httpchk: ""
+
+haproxy_backend_servers: []
+
+haproxy_global_vars:
+  - "log 127.0.0.1 local0"
+  - "log 127.0.0.1 local1 notice"
+  - "chroot /var/lib/haproxy"
+  - "user haproxy"
+  - "group haproxy"
+  - "daemon"
+
+haproxy_defaults_vars:
+  - "option  httplog"
+  - "option  dontlognull"
+  - "timeout connect 5s"
+  - "timeout client  50s"
+  - "timeout server  50s"
+
+haproxy_ssl_certificate: ""
+haproxy_ssl_certificate_content: ""
+
+haproxy_stats_enable: false
+haproxy_stats_user: admin
+haproxy_stats_password: admin
+haproxy_stats_port: 9000
+haproxy_stats_bind_address: "127.0.0.1"

--- a/src/roles/haproxy/handlers/main.yml
+++ b/src/roles/haproxy/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: reload haproxy
+  service:
+    name: "{{ haproxy_service_name }}"
+    state: reloaded

--- a/src/roles/haproxy/meta/main.yml
+++ b/src/roles/haproxy/meta/main.yml
@@ -1,0 +1,11 @@
+---
+galaxy_info:
+  author: your_name
+  description: HAProxy role
+  license: MIT
+  min_ansible_version: "2.10"
+  platforms:
+    - name: Debian
+      versions:
+        - all
+dependencies: []

--- a/src/roles/haproxy/tasks/main.yml
+++ b/src/roles/haproxy/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- name: Install haproxy
+  apt:
+    name: "{{ haproxy_package_name }}"
+    state: present
+  become: yes
+  when: ansible_facts.os_family == 'Debian'
+
+- name: Ensure certificate directory exists
+  file:
+    path: /etc/haproxy/certs
+    state: directory
+    owner: root
+    group: haproxy
+    mode: "0750"
+  when: haproxy_ssl_certificate | length > 0
+
+- name: Deploy certificate
+  copy:
+    content: "{{ haproxy_ssl_certificate_content }}"
+    dest: "{{ haproxy_ssl_certificate }}"
+    owner: root
+    group: haproxy
+    mode: "0640"
+  when: haproxy_ssl_certificate | length > 0 and haproxy_ssl_certificate_content | length > 0
+
+- name: Deploy haproxy configuration
+  template:
+    src: haproxy.cfg.j2
+    dest: /etc/haproxy/haproxy.cfg
+    owner: root
+    group: root
+    mode: "0644"
+  notify: reload haproxy
+
+- name: Enable and start haproxy
+  service:
+    name: "{{ haproxy_service_name }}"
+    state: started
+    enabled: yes

--- a/src/roles/haproxy/templates/haproxy.cfg.j2
+++ b/src/roles/haproxy/templates/haproxy.cfg.j2
@@ -1,0 +1,37 @@
+global
+{% for line in haproxy_global_vars %}
+    {{ line }}
+{% endfor %}
+    maxconn 2048
+    stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
+    pidfile /run/haproxy.pid
+
+defaults
+{% for line in haproxy_defaults_vars %}
+    {{ line }}
+{% endfor %}
+
+{% if haproxy_stats_enable %}
+listen stats
+    bind {{ haproxy_stats_bind_address }}:{{ haproxy_stats_port }}
+    mode http
+    stats enable
+    stats uri /haproxy?stats
+    stats refresh 10s
+    stats auth {{ haproxy_stats_user }}:{{ haproxy_stats_password }}
+{% endif %}
+
+frontend {{ haproxy_frontend_name }}
+    bind {{ haproxy_frontend_bind_address }}:{{ haproxy_frontend_port }}{% if haproxy_ssl_certificate %} ssl crt {{ haproxy_ssl_certificate }}{% endif %}
+    mode {{ haproxy_frontend_mode }}
+    default_backend {{ haproxy_backend_name }}
+
+backend {{ haproxy_backend_name }}
+    mode {{ haproxy_backend_mode }}
+    balance {{ haproxy_backend_balance_method }}
+{% if haproxy_backend_httpchk %}
+    option httpchk {{ haproxy_backend_httpchk }}
+{% endif %}
+{% for srv in haproxy_backend_servers %}
+    server {{ srv.name }} {{ srv.address }} check
+{% endfor %}

--- a/src/roles/keepalived/defaults/main.yml
+++ b/src/roles/keepalived/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+keepalived_package_name: keepalived
+keepalived_service_name: keepalived
+
+keepalived_state: BACKUP
+keepalived_priority: 100
+keepalived_interface: eth0
+keepalived_router_id: 51
+keepalived_virtual_ip: 192.168.50.100
+keepalived_virtual_cidr: 32
+keepalived_auth_pass: vrrp_secret

--- a/src/roles/keepalived/handlers/main.yml
+++ b/src/roles/keepalived/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart keepalived
+  service:
+    name: "{{ keepalived_service_name }}"
+    state: restarted

--- a/src/roles/keepalived/meta/main.yml
+++ b/src/roles/keepalived/meta/main.yml
@@ -1,0 +1,11 @@
+---
+galaxy_info:
+  author: your_name
+  description: Keepalived role
+  license: MIT
+  min_ansible_version: "2.10"
+  platforms:
+    - name: Debian
+      versions:
+        - all
+dependencies: []

--- a/src/roles/keepalived/tasks/main.yml
+++ b/src/roles/keepalived/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Install keepalived
+  apt:
+    name: "{{ keepalived_package_name }}"
+    state: present
+  become: yes
+  when: ansible_facts.os_family == 'Debian'
+
+- name: Deploy keepalived configuration
+  template:
+    src: keepalived.conf.j2
+    dest: /etc/keepalived/keepalived.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: restart keepalived
+
+- name: Enable and start keepalived
+  service:
+    name: "{{ keepalived_service_name }}"
+    state: started
+    enabled: yes

--- a/src/roles/keepalived/templates/keepalived.conf.j2
+++ b/src/roles/keepalived/templates/keepalived.conf.j2
@@ -1,0 +1,14 @@
+vrrp_instance VI_{{ keepalived_router_id }} {
+    state {{ keepalived_state }}
+    interface {{ keepalived_interface }}
+    virtual_router_id {{ keepalived_router_id }}
+    priority {{ keepalived_priority }}
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass {{ keepalived_auth_pass }}
+    }
+    virtual_ipaddress {
+        {{ keepalived_virtual_ip }}/{{ keepalived_virtual_cidr }}
+    }
+}


### PR DESCRIPTION
## Summary
- add HAProxy role with configuration template and defaults
- add Keepalived role with configuration template and defaults
- configure group and host variables for load balancer nodes
- add inventory and playbooks for HAProxy deployment

## Testing
- `git status --short`