### PR TITLE
Add NetBox role with supporting configs

### DIFF
--- a/src/ansible.cfg
+++ b/src/ansible.cfg
@@ -1,7 +1,8 @@
 [defaults]
+remote_user = ansible
 host_key_checking = False
-roles_path = ./roles:/home/toothkiller/.ansible/roles/
+inventory = inventories/production/hosts.yml
 retry_files_enabled = False
-pipelining = True
+stdout_callback = yaml
+roles_path = roles
 forks = 20
-allow_world_readable_tmpfiles = True

--- a/src/inventories/production/group_vars/netbox_app_servers.yml
+++ b/src/inventories/production/group_vars/netbox_app_servers.yml
@@ -1,0 +1,17 @@
+---
+netbox_version: "3.5.6"
+netbox_install_dir: "/opt/netbox"
+netbox_user: "netbox"
+netbox_allowed_hosts:
+  - "netbox.example.com"
+
+postgres_host: "{{ groups['netbox_db_servers'][0] }}"
+postgres_port: 5432
+postgres_db: "netbox"
+postgres_user: "netbox"
+postgres_password: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=secret/netbox/db field=password token={{ lookup("env", "VAULT_TOKEN") }}') }}"
+
+redis_host: "netbox-redis.prod.local"
+redis_port: 6379
+
+netbox_secret_key: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=secret/netbox/app field=secret_key token={{ lookup("env", "VAULT_TOKEN") }}') }}"

--- a/src/inventories/production/hosts.yml
+++ b/src/inventories/production/hosts.yml
@@ -1,10 +1,12 @@
-dns_primary:
-  hosts:
-    dns-prod-01:
-      ansible_host: 192.168.10.10
-dns_secondary:
-  hosts:
-    dns-prod-02:
-      ansible_host: 192.168.10.11
-    dns-prod-03:
-      ansible_host: 192.168.10.12
+all:
+  children:
+    netbox_app_servers:
+      hosts:
+        netbox1.prod.local:
+          ansible_host: 10.0.0.101
+        netbox2.prod.local:
+          ansible_host: 10.0.0.102
+    netbox_db_servers:
+      hosts:
+        netbox-db1.prod.local:
+          ansible_host: 10.0.1.10

--- a/src/playbooks/deploy-netbox.yml
+++ b/src/playbooks/deploy-netbox.yml
@@ -1,0 +1,8 @@
+---
+- name: Deploy NetBox
+  hosts: netbox_app_servers
+  become: true
+  serial: 1
+  roles:
+    - netbox
+    - filebeat

--- a/src/playbooks/netbox-backup.yml
+++ b/src/playbooks/netbox-backup.yml
@@ -1,0 +1,6 @@
+---
+- name: Backup NetBox
+  hosts: netbox_db_servers[0]
+  become: true
+  roles:
+    - backup_netbox

--- a/src/playbooks/setup-db.yml
+++ b/src/playbooks/setup-db.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure PostgreSQL
+  hosts: netbox_db_servers
+  become: true
+  roles:
+    - geerlingguy.postgresql

--- a/src/playbooks/setup-redis.yml
+++ b/src/playbooks/setup-redis.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure Redis
+  hosts: netbox_cache_servers
+  become: true
+  roles:
+    - geerlingguy.redis

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -1,0 +1,4 @@
+---
+- import_playbook: setup-db.yml
+- import_playbook: setup-redis.yml
+- import_playbook: deploy-netbox.yml

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -1,0 +1,12 @@
+---
+roles:
+  - name: geerlingguy.postgresql
+    version: "3.3.0"
+  - name: geerlingguy.redis
+    version: "1.7.0"
+
+collections:
+  - name: community.hashi_vault
+    version: "2.6.0"
+  - name: community.general
+    version: "8.6.0"

--- a/src/roles/backup_netbox/tasks/main.yml
+++ b/src/roles/backup_netbox/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Create backup directory
+  ansible.builtin.file:
+    path: /var/backups/netbox
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+
+- name: Backup PostgreSQL database
+  community.postgresql.postgresql_db:
+    name: "{{ postgres_db }}"
+    target: "/var/backups/netbox/netbox_{{ ansible_date_time.iso8601_basic_short }}.sql"
+    login_host: "{{ postgres_host }}"
+    login_user: "{{ postgres_user }}"
+    login_password: "{{ postgres_password }}"
+  become_user: postgres
+
+- name: Archive NetBox media
+  ansible.builtin.archive:
+    path: "{{ netbox_media_root }}"
+    dest: "/var/backups/netbox/netbox_media_{{ ansible_date_time.iso8601_basic_short }}.tgz"
+    format: gz

--- a/src/roles/filebeat/handlers/main.yml
+++ b/src/roles/filebeat/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart filebeat
+  ansible.builtin.service:
+    name: filebeat
+    state: restarted

--- a/src/roles/filebeat/tasks/main.yml
+++ b/src/roles/filebeat/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Install Filebeat
+  ansible.builtin.apt:
+    pkg: filebeat
+    state: present
+    update_cache: yes
+
+- name: Deploy Filebeat config
+  ansible.builtin.template:
+    src: filebeat.yml.j2
+    dest: /etc/filebeat/filebeat.yml
+    mode: "0644"
+  notify: restart filebeat
+
+- name: Enable and start Filebeat
+  ansible.builtin.service:
+    name: filebeat
+    enabled: yes
+    state: started

--- a/src/roles/filebeat/templates/filebeat.yml.j2
+++ b/src/roles/filebeat/templates/filebeat.yml.j2
@@ -1,0 +1,10 @@
+filebeat.inputs:
+  - type: log
+    paths:
+      - /var/log/netbox/netbox.log
+    fields:
+      service: netbox
+      environment: "{{ ansible_facts.env | default('production') }}"
+
+output.logstash:
+  hosts: ["logstash.example.com:5044"]

--- a/src/roles/netbox/defaults/main.yml
+++ b/src/roles/netbox/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+netbox_git_repo: "https://github.com/netbox-community/netbox.git"
+netbox_branch: "master"
+netbox_systemd_unit: "/etc/systemd/system/netbox.service"
+netbox_python: "python3"
+netbox_venv: "/opt/netbox/venv"
+netbox_uwsgi_socket: "/run/netbox/netbox.sock"
+netbox_media_root: "{{ netbox_install_dir }}/netbox/media"
+netbox_static_root: "{{ netbox_install_dir }}/netbox/static"

--- a/src/roles/netbox/handlers/main.yml
+++ b/src/roles/netbox/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: restart netbox
+  ansible.builtin.systemd:
+    name: netbox
+    state: restarted
+    daemon_reload: yes
+
+- name: reload nginx
+  ansible.builtin.service:
+    name: nginx
+    state: reloaded

--- a/src/roles/netbox/meta/main.yml
+++ b/src/roles/netbox/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: geerlingguy.postgresql
+  - role: geerlingguy.redis

--- a/src/roles/netbox/tasks/config.yml
+++ b/src/roles/netbox/tasks/config.yml
@@ -1,0 +1,24 @@
+---
+- name: Template configuration.py
+  ansible.builtin.template:
+    src: configuration.py.j2
+    dest: "{{ netbox_install_dir }}/netbox/netbox/configuration.py"
+    owner: "{{ netbox_user }}"
+    group: "{{ netbox_user }}"
+    mode: "0640"
+  notify: restart netbox
+
+- name: Template systemd service
+  ansible.builtin.template:
+    src: netbox.service.j2
+    dest: "{{ netbox_systemd_unit }}"
+    mode: "0644"
+  notify: restart netbox
+
+- name: Ensure log directory exists
+  ansible.builtin.file:
+    path: /var/log/netbox
+    state: directory
+    owner: "{{ netbox_user }}"
+    group: "{{ netbox_user }}"
+    mode: "0755"

--- a/src/roles/netbox/tasks/install.yml
+++ b/src/roles/netbox/tasks/install.yml
@@ -1,0 +1,39 @@
+---
+- name: Ensure prerequisite packages installed
+  ansible.builtin.apt:
+    name:
+      - git
+      - python3-venv
+      - python3-dev
+      - build-essential
+      - libxml2-dev
+      - libffi-dev
+      - libpq-dev
+      - libssl-dev
+    state: present
+    update_cache: yes
+
+- name: Create netbox system user
+  ansible.builtin.user:
+    name: "{{ netbox_user }}"
+    system: yes
+    create_home: no
+    shell: /usr/sbin/nologin
+
+- name: Clone NetBox repository
+  ansible.builtin.git:
+    repo: "{{ netbox_git_repo }}"
+    dest: "{{ netbox_install_dir }}"
+    version: "{{ netbox_branch }}"
+    force: yes
+  notify: restart netbox
+
+- name: Create virtualenv
+  ansible.builtin.command: "{{ netbox_python }} -m venv {{ netbox_venv }}"
+  args:
+    creates: "{{ netbox_venv }}/bin/activate"
+
+- name: Install NetBox requirements
+  ansible.builtin.pip:
+    requirements: "{{ netbox_install_dir }}/requirements.txt"
+    virtualenv: "{{ netbox_venv }}"

--- a/src/roles/netbox/tasks/main.yml
+++ b/src/roles/netbox/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- ansible.builtin.include_tasks: install.yml
+- ansible.builtin.include_tasks: config.yml
+- ansible.builtin.include_tasks: migrate.yml
+- ansible.builtin.include_tasks: service.yml

--- a/src/roles/netbox/tasks/migrate.yml
+++ b/src/roles/netbox/tasks/migrate.yml
@@ -1,0 +1,14 @@
+---
+- name: Apply database migrations
+  ansible.builtin.command: "{{ netbox_venv }}/bin/python3 manage.py migrate --no-input"
+  args:
+    chdir: "{{ netbox_install_dir }}/netbox"
+  when: inventory_hostname == groups['netbox_app_servers'][0]
+  notify: restart netbox
+
+- name: Collect static files
+  ansible.builtin.command: "{{ netbox_venv }}/bin/python3 manage.py collectstatic --no-input"
+  args:
+    chdir: "{{ netbox_install_dir }}/netbox"
+  when: inventory_hostname == groups['netbox_app_servers'][0]
+  notify: restart netbox

--- a/src/roles/netbox/tasks/service.yml
+++ b/src/roles/netbox/tasks/service.yml
@@ -1,0 +1,10 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: yes
+
+- name: Enable and start NetBox
+  ansible.builtin.systemd:
+    name: netbox
+    enabled: yes
+    state: started

--- a/src/roles/netbox/templates/configuration.py.j2
+++ b/src/roles/netbox/templates/configuration.py.j2
@@ -1,0 +1,49 @@
+ALLOWED_HOSTS = {{ netbox_allowed_hosts | to_json }}
+DATABASE = {
+    'NAME': '{{ postgres_db }}',
+    'USER': '{{ postgres_user }}',
+    'PASSWORD': '{{ postgres_password }}',
+    'HOST': '{{ postgres_host }}',
+    'PORT': '{{ postgres_port }}',
+}
+REDIS = {
+    'tasks': {
+        'HOST': '{{ redis_host }}',
+        'PORT': {{ redis_port }},
+        'PASSWORD': '',
+        'DATABASE': 0,
+    },
+    'caching': {
+        'HOST': '{{ redis_host }}',
+        'PORT': {{ redis_port }},
+        'PASSWORD': '',
+        'DATABASE': 1,
+    }
+}
+SECRET_KEY = '{{ netbox_secret_key }}'
+MEDIA_ROOT = '{{ netbox_media_root }}'
+STATIC_ROOT = '{{ netbox_static_root }}'
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'file': {
+            'level': 'INFO',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': '/var/log/netbox/netbox.log',
+            'maxBytes': 10485760,
+            'backupCount': 5,
+            'formatter': 'verbose',
+        },
+    },
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(name)s %(message)s'
+        },
+    },
+    'root': {
+        'handlers': ['file'],
+        'level': 'INFO',
+    },
+}

--- a/src/roles/netbox/templates/netbox.service.j2
+++ b/src/roles/netbox/templates/netbox.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=NetBox WSGI Service
+After=network.target
+
+[Service]
+Type=simple
+User={{ netbox_user }}
+Group={{ netbox_user }}
+WorkingDirectory={{ netbox_install_dir }}/netbox
+ExecStart={{ netbox_venv }}/bin/gunicorn --workers 4 --bind 0.0.0.0:8000 netbox.wsgi
+Environment="DJANGO_SETTINGS_MODULE=netbox.settings"
+Environment="PYTHONPATH={{ netbox_install_dir }}/netbox"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- create NetBox deployment role with handlers and tasks
- add Filebeat role to ship logs
- add backup role for NetBox data
- provide playbooks for deploying and backing up NetBox
- configure inventory and Ansible settings for NetBox
- define dependencies in requirements file

## Testing
- `ansible-playbook --version` *(fails: command not found)*