### PR TITLE
Add Jenkins roles and playbooks

### DIFF
--- a/src/inventories/production/group_vars/jenkins_agents.yml
+++ b/src/inventories/production/group_vars/jenkins_agents.yml
@@ -1,0 +1,6 @@
+---
+jenkins_agent_user: jenkins
+jenkins_agent_home: /home/jenkins
+jenkins_controller_url: "http://jenkins-controller-01:8080"
+jenkins_agent_ssh_private_key: "{{ vault_jenkins_agent_private_key }}"
+jenkins_agent_ssh_public_key: "{{ vault_jenkins_agent_public_key }}"

--- a/src/inventories/production/group_vars/jenkins_controllers.yml
+++ b/src/inventories/production/group_vars/jenkins_controllers.yml
@@ -1,0 +1,11 @@
+---
+jenkins_version: "2.452.2"           # LTS version
+jenkins_http_port: 8080
+jenkins_admin_user: "admin"
+jenkins_admin_password: "{{ vault_jenkins_admin_password }}"
+jenkins_plugins:
+  - git
+  - matrix-auth
+  - job-dsl
+  - configuration-as-code
+jenkins_java_opts: "-Xms512m -Xmx2048m"

--- a/src/inventories/production/hosts.yml
+++ b/src/inventories/production/hosts.yml
@@ -10,3 +10,10 @@ all:
       hosts:
         netbox-db1.prod.local:
           ansible_host: 10.0.1.10
+    jenkins_controllers:
+      hosts:
+        jenkins-controller-01:
+    jenkins_agents:
+      hosts:
+        jenkins-agent-01:
+        jenkins-agent-02:

--- a/src/playbooks/jenkins/backup.yml
+++ b/src/playbooks/jenkins/backup.yml
@@ -1,0 +1,5 @@
+---
+- hosts: jenkins_controllers
+  become: yes
+  roles:
+    - jenkins_backup

--- a/src/playbooks/jenkins/site.yml
+++ b/src/playbooks/jenkins/site.yml
@@ -1,0 +1,10 @@
+---
+- hosts: jenkins_controllers
+  become: yes
+  roles:
+    - jenkins_controller
+
+- hosts: jenkins_agents
+  become: yes
+  roles:
+    - jenkins_agent

--- a/src/roles/jenkins_agent/defaults/main.yml
+++ b/src/roles/jenkins_agent/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+jenkins_agent_user: jenkins
+jenkins_agent_home: "/home/{{ jenkins_agent_user }}"
+jenkins_agent_executors: 2
+jenkins_agent_labels: "linux"

--- a/src/roles/jenkins_agent/handlers/main.yml
+++ b/src/roles/jenkins_agent/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart ssh
+  ansible.builtin.service:
+    name: ssh
+    state: restarted

--- a/src/roles/jenkins_agent/tasks/main.yml
+++ b/src/roles/jenkins_agent/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: ensure jenkins user
+  ansible.builtin.user:
+    name: "{{ jenkins_agent_user }}"
+    home: "{{ jenkins_agent_home }}"
+    shell: /bin/bash
+    create_home: yes
+
+- name: install openjdk
+  ansible.builtin.apt:
+    name: openjdk-11-jdk
+    state: present
+    update_cache: yes
+
+- name: deploy controller public key
+  ansible.builtin.authorized_key:
+    user: "{{ jenkins_agent_user }}"
+    key: "{{ jenkins_agent_ssh_public_key }}"
+    state: present
+  notify: restart ssh

--- a/src/roles/jenkins_backup/tasks/main.yml
+++ b/src/roles/jenkins_backup/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: create backup dir
+  ansible.builtin.file:
+    path: "{{ jenkins_backup_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: archive jenkins home
+  ansible.builtin.archive:
+    path: "{{ jenkins_home }}/"
+    dest: "{{ jenkins_backup_dir }}/jenkins-{{ ansible_date_time.date }}.tar.gz"
+    format: gz
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: prune old backups
+  ansible.builtin.find:
+    paths: "{{ jenkins_backup_dir }}"
+    age: "{{ jenkins_backup_keep_days }}d"
+    patterns: "jenkins-*.tar.gz"
+  register: old_backups
+
+- name: remove old backups
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ old_backups.files }}"

--- a/src/roles/jenkins_controller/defaults/main.yml
+++ b/src/roles/jenkins_controller/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+jenkins_repo_url: "https://pkg.jenkins.io/debian-stable"
+jenkins_repo_key_url: "https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key"
+jenkins_home: "/var/lib/jenkins"
+jenkins_plugins_state: present
+jenkins_backup_dir: "/var/backups/jenkins"
+jenkins_backup_keep_days: 7

--- a/src/roles/jenkins_controller/handlers/main.yml
+++ b/src/roles/jenkins_controller/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart jenkins
+  ansible.builtin.service:
+    name: jenkins
+    state: restarted

--- a/src/roles/jenkins_controller/tasks/main.yml
+++ b/src/roles/jenkins_controller/tasks/main.yml
@@ -1,0 +1,68 @@
+---
+- name: ensure apt deps
+  ansible.builtin.apt:
+    name:
+      - gnupg
+      - curl
+    state: present
+    update_cache: yes
+
+- name: add jenkins apt key
+  ansible.builtin.get_url:
+    url: "{{ jenkins_repo_key_url }}"
+    dest: /usr/share/keyrings/jenkins.gpg
+    mode: "0644"
+    force: yes
+
+- name: add jenkins apt repository
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/usr/share/keyrings/jenkins.gpg] {{ jenkins_repo_url }} binary/"
+    filename: jenkins
+    state: present
+
+- name: install jenkins and java
+  ansible.builtin.apt:
+    name:
+      - openjdk-11-jdk
+      - "jenkins={{ jenkins_version }}*"
+    state: present
+    update_cache: yes
+  notify: restart jenkins
+
+- name: disable setup wizard
+  ansible.builtin.lineinfile:
+    path: /etc/default/jenkins
+    regexp: '^JENKINS_ARGS='
+    line: 'JENKINS_ARGS="--webroot=/var/cache/$NAME/war --httpPort={{ jenkins_http_port }} -Djenkins.install.runSetupWizard=false {{ jenkins_java_opts }}"'
+  notify: restart jenkins
+
+- name: deploy admin groovy init
+  ansible.builtin.template:
+    src: init_admin_user.groovy.j2
+    dest: "{{ jenkins_home }}/init.groovy.d/init_admin_user.groovy"
+    owner: jenkins
+    group: jenkins
+    mode: "0644"
+  notify: restart jenkins
+
+- name: create plugins list
+  ansible.builtin.template:
+    src: plugins.txt.j2
+    dest: /opt/jenkins_plugins.txt
+    mode: "0644"
+
+- name: install required plugins offline
+  ansible.builtin.command: >
+    java -jar /usr/share/jenkins/jenkins-plugin-manager.jar
+    --war /usr/share/jenkins/jenkins.war
+    --plugin-file /opt/jenkins_plugins.txt
+    --plugin-download-directory {{ jenkins_home }}/plugins
+  args:
+    creates: "{{ jenkins_home }}/plugins/{{ jenkins_plugins[0] }}.jpi"
+  notify: restart jenkins
+
+- name: ensure jenkins service enabled and started
+  ansible.builtin.service:
+    name: jenkins
+    state: started
+    enabled: yes

--- a/src/roles/jenkins_controller/templates/init_admin_user.groovy.j2
+++ b/src/roles/jenkins_controller/templates/init_admin_user.groovy.j2
@@ -1,0 +1,13 @@
+import jenkins.model.*
+import hudson.security.*
+
+def instance = Jenkins.getInstance()
+def hudsonRealm = new HudsonPrivateSecurityRealm(false)
+if(!hudsonRealm.getAllUsers().any { it.getId() == "{{ jenkins_admin_user }}" }){
+  hudsonRealm.createAccount("{{ jenkins_admin_user }}", "{{ jenkins_admin_password }}")
+  instance.setSecurityRealm(hudsonRealm)
+  def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
+  strategy.setAllowAnonymousRead(false)
+  instance.setAuthorizationStrategy(strategy)
+  instance.save()
+}

--- a/src/roles/jenkins_controller/templates/plugins.txt.j2
+++ b/src/roles/jenkins_controller/templates/plugins.txt.j2
@@ -1,0 +1,3 @@
+{% for plugin in jenkins_plugins %}
+{{ plugin }}
+{% endfor %}


### PR DESCRIPTION
## Summary
- inventory: add Jenkins controller and agent hosts
- production group vars for Jenkins controllers/agents
- roles for `jenkins_controller`, `jenkins_agent` and backups
- playbooks to deploy and back up Jenkins

## Testing
- `git status --short`