### PR TITLE
Add Elasticsearch roles and inventory

### DIFF
--- a/src/ansible.cfg
+++ b/src/ansible.cfg
@@ -1,8 +1,5 @@
 [defaults]
-remote_user = ansible
-host_key_checking = False
-inventory = inventories/production/hosts.yml
-retry_files_enabled = False
-stdout_callback = yaml
+inventory = inventories/production/hosts.ini
 roles_path = roles
-forks = 20
+forks = 10
+pipelining = True

--- a/src/inventories/production/group_vars/all.yml
+++ b/src/inventories/production/group_vars/all.yml
@@ -1,0 +1,20 @@
+---
+es_cluster_name: "prod-es-cluster"
+elasticsearch_version: "8.8.0"
+
+# Snapshot settings
+es_snapshot_repo_name: "backup_repo"
+es_snapshot_repo_type: "fs"
+es_snapshot_repo_settings:
+  location: "/mnt/elasticsearch_snapshots"
+  compress: true
+es_use_slm: true
+
+# LDAP settings
+ldap_url: "ldaps://ldap.example.com:636"
+ldap_bind_dn: "cn=readbind,ou=users,dc=example,dc=com"
+ldap_bind_password: "{{ vault_ldap_bind_password }}"
+ldap_user_base_dn: "ou=users,dc=example,dc=com"
+ldap_group_base_dn: "ou=groups,dc=example,dc=com"
+ldap_admin_group_dn: "cn=admins,dc=example,dc=com"
+ldap_user_group_dn: "cn=users,dc=example,dc=com"

--- a/src/inventories/production/group_vars/es_coord.yml
+++ b/src/inventories/production/group_vars/es_coord.yml
@@ -1,0 +1,5 @@
+---
+node_roles:
+  - remote_cluster_client
+  - ingest
+elasticsearch_heap_size: "4g"

--- a/src/inventories/production/group_vars/es_data.yml
+++ b/src/inventories/production/group_vars/es_data.yml
@@ -1,0 +1,4 @@
+---
+node_roles:
+  - data
+elasticsearch_heap_size: "8g"

--- a/src/inventories/production/group_vars/es_master.yml
+++ b/src/inventories/production/group_vars/es_master.yml
@@ -1,0 +1,4 @@
+---
+node_roles:
+  - master
+elasticsearch_heap_size: "2g"

--- a/src/inventories/production/hosts.ini
+++ b/src/inventories/production/hosts.ini
@@ -1,0 +1,16 @@
+[es_master]
+es-node1 ansible_host=10.0.0.1
+es-node2 ansible_host=10.0.0.2
+es-node3 ansible_host=10.0.0.3
+
+[es_data]
+es-node4 ansible_host=10.0.0.4
+es-node5 ansible_host=10.0.0.5
+
+[es_coord]
+es-node6 ansible_host=10.0.0.6
+
+[elasticsearch:children]
+es_master
+es_data
+es_coord

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -1,4 +1,9 @@
 ---
-- import_playbook: setup-db.yml
-- import_playbook: setup-redis.yml
-- import_playbook: deploy-netbox.yml
+- name: Install and configure Elasticsearch cluster
+  hosts: elasticsearch
+  become: yes
+  roles:
+    - role: elasticsearch_install
+    - role: elasticsearch_config
+    - role: elasticsearch_security
+    - role: elasticsearch_snapshot

--- a/src/roles/elasticsearch_config/defaults/main.yml
+++ b/src/roles/elasticsearch_config/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+elasticsearch_heap_size: "2g"

--- a/src/roles/elasticsearch_config/meta/main.yml
+++ b/src/roles/elasticsearch_config/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/src/roles/elasticsearch_config/tasks/config.yml
+++ b/src/roles/elasticsearch_config/tasks/config.yml
@@ -1,0 +1,9 @@
+---
+- name: Template elasticsearch.yml
+  template:
+    src: elasticsearch.yml.j2
+    dest: /etc/elasticsearch/elasticsearch.yml
+    owner: root
+    group: elasticsearch
+    mode: '0640'
+  notify: restart elasticsearch

--- a/src/roles/elasticsearch_config/tasks/jvm.yml
+++ b/src/roles/elasticsearch_config/tasks/jvm.yml
@@ -1,0 +1,9 @@
+---
+- name: Template JVM options
+  template:
+    src: jvm.options.j2
+    dest: /etc/elasticsearch/jvm.options.d/heap.options
+    owner: root
+    group: elasticsearch
+    mode: '0644'
+  notify: restart elasticsearch

--- a/src/roles/elasticsearch_config/tasks/main.yml
+++ b/src/roles/elasticsearch_config/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- import_tasks: config.yml
+- import_tasks: jvm.yml

--- a/src/roles/elasticsearch_config/templates/elasticsearch.yml.j2
+++ b/src/roles/elasticsearch_config/templates/elasticsearch.yml.j2
@@ -1,0 +1,16 @@
+cluster.name: "{{ es_cluster_name }}"
+node.name: "{{ inventory_hostname }}"
+node.roles: {{ node_roles | to_json }}
+
+network.host: "{{ ansible_default_ipv4.address }}"
+http.port: 9200
+
+{% if groups['es_master'] | length > 1 %}
+discovery.seed_hosts: {{ groups['es_master'] | map('extract', hostvars, 'ansible_default_ipv4.address') | list }}
+cluster.initial_master_nodes: {{ groups['es_master'] | list }}
+{% else %}
+discovery.type: single-node
+{% endif %}
+
+path.data: /var/lib/elasticsearch
+path.logs: /var/log/elasticsearch

--- a/src/roles/elasticsearch_config/templates/jvm.options.j2
+++ b/src/roles/elasticsearch_config/templates/jvm.options.j2
@@ -1,0 +1,2 @@
+-Xms{{ elasticsearch_heap_size }}
+-Xmx{{ elasticsearch_heap_size }}

--- a/src/roles/elasticsearch_install/defaults/main.yml
+++ b/src/roles/elasticsearch_install/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+elasticsearch_version: "8.8.0"
+java_install: true

--- a/src/roles/elasticsearch_install/handlers/main.yml
+++ b/src/roles/elasticsearch_install/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: update apt cache
+  apt:
+    update_cache: yes
+
+- name: restart elasticsearch
+  service:
+    name: elasticsearch
+    state: restarted

--- a/src/roles/elasticsearch_install/meta/main.yml
+++ b/src/roles/elasticsearch_install/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: geerlingguy.java
+    when: java_install | default(true)

--- a/src/roles/elasticsearch_install/tasks/install.yml
+++ b/src/roles/elasticsearch_install/tasks/install.yml
@@ -1,0 +1,25 @@
+---
+- name: Ensure apt-transport-https is installed
+  apt:
+    name: apt-transport-https
+    state: present
+    update_cache: yes
+
+- name: Add Elasticsearch GPG key
+  apt_key:
+    url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
+    state: present
+
+- name: Add Elasticsearch repository
+  template:
+    src: elasticsearch.list.j2
+    dest: /etc/apt/sources.list.d/elasticsearch.list
+    mode: '0644'
+  notify: update apt cache
+
+- name: Install Elasticsearch
+  apt:
+    name: "elasticsearch={{ elasticsearch_version }}"
+    state: present
+    update_cache: yes
+  notify: restart elasticsearch

--- a/src/roles/elasticsearch_install/tasks/main.yml
+++ b/src/roles/elasticsearch_install/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- import_tasks: install.yml
+- import_tasks: service.yml

--- a/src/roles/elasticsearch_install/tasks/service.yml
+++ b/src/roles/elasticsearch_install/tasks/service.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure Elasticsearch service enabled
+  service:
+    name: elasticsearch
+    enabled: yes
+    state: stopped

--- a/src/roles/elasticsearch_install/templates/elasticsearch.list.j2
+++ b/src/roles/elasticsearch_install/templates/elasticsearch.list.j2
@@ -1,0 +1,1 @@
+deb [trusted=yes] https://artifacts.elastic.co/packages/{{ elasticsearch_version | regex_replace('\\..*$', '') }}/apt stable main

--- a/src/roles/elasticsearch_security/defaults/main.yml
+++ b/src/roles/elasticsearch_security/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+es_tls_provided: false

--- a/src/roles/elasticsearch_security/meta/main.yml
+++ b/src/roles/elasticsearch_security/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/src/roles/elasticsearch_security/tasks/certs.yml
+++ b/src/roles/elasticsearch_security/tasks/certs.yml
@@ -1,0 +1,48 @@
+---
+- name: Ensure certificate directory exists
+  file:
+    path: /etc/elasticsearch/certs
+    state: directory
+    owner: root
+    group: elasticsearch
+    mode: '0750'
+
+- name: Copy node certificate
+  copy:
+    src: "{{ inventory_hostname }}.crt"
+    dest: "/etc/elasticsearch/certs/{{ inventory_hostname }}.crt"
+    owner: root
+    group: elasticsearch
+    mode: '0644'
+  when: es_tls_provided | default(false)
+
+- name: Copy node key
+  copy:
+    src: "{{ inventory_hostname }}.key"
+    dest: "/etc/elasticsearch/certs/{{ inventory_hostname }}.key"
+    owner: root
+    group: elasticsearch
+    mode: '0600'
+  when: es_tls_provided | default(false)
+
+- name: Copy CA certificate
+  copy:
+    src: cacert.pem
+    dest: /etc/elasticsearch/certs/ca.crt
+    owner: root
+    group: elasticsearch
+    mode: '0644'
+  when: es_tls_provided | default(false)
+
+- name: Configure TLS settings
+  blockinfile:
+    path: /etc/elasticsearch/elasticsearch.yml
+    block: |
+      xpack.security.enabled: true
+      xpack.security.transport.ssl.enabled: true
+      xpack.security.transport.ssl.verification_mode: certificate
+      xpack.security.transport.ssl.key: "/etc/elasticsearch/certs/{{ inventory_hostname }}.key"
+      xpack.security.transport.ssl.certificate: "/etc/elasticsearch/certs/{{ inventory_hostname }}.crt"
+      xpack.security.transport.ssl.certificate_authorities: ["/etc/elasticsearch/certs/ca.crt"]
+  notify: restart elasticsearch
+  when: es_tls_provided | default(false)

--- a/src/roles/elasticsearch_security/tasks/ldap.yml
+++ b/src/roles/elasticsearch_security/tasks/ldap.yml
@@ -1,0 +1,16 @@
+---
+- name: Configure LDAP realm
+  blockinfile:
+    path: /etc/elasticsearch/elasticsearch.yml
+    block: |
+      xpack.security.authc.realms.ldap.ldap1:
+        order: 0
+        url: "{{ ldap_url }}"
+        bind_dn: "{{ ldap_bind_dn }}"
+        bind_password: "{{ ldap_bind_password }}"
+        user_search:
+          base_dn: "{{ ldap_user_base_dn }}"
+        group_search:
+          base_dn: "{{ ldap_group_base_dn }}"
+        files.role_mapping: "/etc/elasticsearch/role_mapping.yml"
+  notify: restart elasticsearch

--- a/src/roles/elasticsearch_security/tasks/main.yml
+++ b/src/roles/elasticsearch_security/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- import_tasks: certs.yml
+- import_tasks: ldap.yml
+- import_tasks: users.yml

--- a/src/roles/elasticsearch_security/tasks/users.yml
+++ b/src/roles/elasticsearch_security/tasks/users.yml
@@ -1,0 +1,9 @@
+---
+- name: Template role mapping file
+  template:
+    src: role_mapping.yml.j2
+    dest: /etc/elasticsearch/role_mapping.yml
+    owner: root
+    group: elasticsearch
+    mode: '0640'
+  notify: restart elasticsearch

--- a/src/roles/elasticsearch_security/templates/role_mapping.yml.j2
+++ b/src/roles/elasticsearch_security/templates/role_mapping.yml.j2
@@ -1,0 +1,4 @@
+superuser:
+  - "{{ ldap_admin_group_dn }}"
+kibana_user:
+  - "{{ ldap_user_group_dn }}"

--- a/src/roles/elasticsearch_snapshot/defaults/main.yml
+++ b/src/roles/elasticsearch_snapshot/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+es_use_slm: true

--- a/src/roles/elasticsearch_snapshot/meta/main.yml
+++ b/src/roles/elasticsearch_snapshot/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/src/roles/elasticsearch_snapshot/tasks/cron.yml
+++ b/src/roles/elasticsearch_snapshot/tasks/cron.yml
@@ -1,0 +1,17 @@
+---
+- name: Install snapshot script
+  template:
+    src: snapshot_script.sh.j2
+    dest: /usr/local/bin/es_snapshot.sh
+    mode: '0750'
+    owner: root
+    group: root
+
+- name: Schedule snapshot via cron
+  cron:
+    name: "Elasticsearch Daily Snapshot"
+    hour: 2
+    minute: 0
+    user: root
+    job: "/usr/local/bin/es_snapshot.sh"
+  when: es_use_slm is not true

--- a/src/roles/elasticsearch_snapshot/tasks/main.yml
+++ b/src/roles/elasticsearch_snapshot/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- import_tasks: repository.yml
+- import_tasks: cron.yml

--- a/src/roles/elasticsearch_snapshot/tasks/repository.yml
+++ b/src/roles/elasticsearch_snapshot/tasks/repository.yml
@@ -1,0 +1,14 @@
+---
+- name: Register snapshot repository
+  uri:
+    url: "http://localhost:9200/_snapshot/{{ es_snapshot_repo_name }}"
+    method: PUT
+    body_format: json
+    body:
+      type: "{{ es_snapshot_repo_type }}"
+      settings: "{{ es_snapshot_repo_settings }}"
+    status_code: 200
+    user: "{{ elastic_api_user | default('elastic') }}"
+    password: "{{ elastic_api_password | default(vault_elastic_password) }}"
+  run_once: true
+  delegate_to: "{{ groups['es_master'][0] }}"

--- a/src/roles/elasticsearch_snapshot/templates/slm_policy.json.j2
+++ b/src/roles/elasticsearch_snapshot/templates/slm_policy.json.j2
@@ -1,0 +1,13 @@
+{
+  "schedule": "0 2 * * *",
+  "name": "<daily-snap-{now/d}>",
+  "repository": "{{ es_snapshot_repo_name }}",
+  "config": {
+    "indices": "*",
+    "ignore_unavailable": true
+  },
+  "retention": {
+    "expire_after": "30d",
+    "max_count": 30
+  }
+}

--- a/src/roles/elasticsearch_snapshot/templates/snapshot_script.sh.j2
+++ b/src/roles/elasticsearch_snapshot/templates/snapshot_script.sh.j2
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+SNAP_NAME="snap-$(date +%Y%m%d%H%M)"
+curl -s -u {{ elastic_api_user | default('elastic') }}:{{ elastic_api_password | default("$ELASTIC_PASSWORD") }} \
+  -H "Content-Type: application/json" \
+  -X PUT "http://localhost:9200/_snapshot/{{ es_snapshot_repo_name }}/$SNAP_NAME?wait_for_completion=false" \
+  -d '{}'


### PR DESCRIPTION
## Summary
- configure new ansible.cfg for Elasticsearch inventory
- add production inventory and group_vars for Elasticsearch nodes
- implement Elasticsearch roles for install, config, security and snapshot
- update site playbook to use the new roles

## Testing
- `git status --short`