### PR TITLE
Add Cloudflare front door role

### DIFF
--- a/src/ansible.cfg
+++ b/src/ansible.cfg
@@ -1,5 +1,9 @@
 [defaults]
-inventory = inventories/production/hosts.ini
 roles_path = roles
-forks = 10
-pipelining = True
+collections_paths = collections
+retry_files_enabled = false
+stdout_callback = yaml
+inventory = inventories/production
+
+[privilege_escalation]
+become = false

--- a/src/inventories/production/group_vars/all.yml
+++ b/src/inventories/production/group_vars/all.yml
@@ -18,3 +18,33 @@ ldap_user_base_dn: "ou=users,dc=example,dc=com"
 ldap_group_base_dn: "ou=groups,dc=example,dc=com"
 ldap_admin_group_dn: "cn=admins,dc=example,dc=com"
 ldap_user_group_dn: "cn=users,dc=example,dc=com"
+
+# Cloudflare front door settings
+cloudflare_api_token: "{{ lookup('env', 'CLOUDFLARE_TOKEN') }}"
+cloudflare_zone: "example.com"
+cloudflare_zone_id: "YOUR_ZONE_ID"
+
+cloudflare_ssl_mode: "strict"
+cloudflare_always_use_https: true
+
+cloudflare_dns_records:
+  - record: "@"
+    type: A
+    value: "203.0.113.45"
+    proxied: true
+    ttl: 1
+  - record: "www"
+    type: CNAME
+    value: "@"
+    proxied: true
+    ttl: 1
+
+cloudflare_firewall_rules:
+  - target: "country"
+    value: "RU"
+    mode: "block"
+    note: "Block traffic from Russia"
+  - target: "ip"
+    value: "198.51.100.0/24"
+    mode: "challenge"
+    note: "Challenge suspicious subnet"

--- a/src/inventories/production/hosts
+++ b/src/inventories/production/hosts
@@ -1,0 +1,2 @@
+[cloudflare]
+localhost ansible_connection=local

--- a/src/playbooks/cloudflare_setup.yml
+++ b/src/playbooks/cloudflare_setup.yml
@@ -1,0 +1,7 @@
+---
+- name: Configure Cloudflare front door
+  hosts: cloudflare
+  gather_facts: false
+  connection: local
+  roles:
+    - cloudflare

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -10,3 +10,5 @@ collections:
     version: "2.6.0"
   - name: community.general
     version: "8.6.0"
+  - name: community.cloudflare
+    version: ">=2.0.0"

--- a/src/roles/cloudflare/tasks/dns.yml
+++ b/src/roles/cloudflare/tasks/dns.yml
@@ -1,0 +1,12 @@
+---
+- name: Manage Cloudflare DNS records
+  community.cloudflare.cloudflare_dns:
+    zone: "{{ cloudflare_zone }}"
+    record: "{{ item.record }}"
+    type: "{{ item.type }}"
+    value: "{{ item.value }}"
+    proxied: "{{ item.proxied | default(false) }}"
+    ttl: "{{ item.ttl | default(1) }}"
+    api_token: "{{ cloudflare_api_token }}"
+    state: present
+  loop: "{{ cloudflare_dns_records }}"

--- a/src/roles/cloudflare/tasks/firewall.yml
+++ b/src/roles/cloudflare/tasks/firewall.yml
@@ -1,0 +1,36 @@
+---
+- name: Get existing firewall access rules
+  uri:
+    url: "https://api.cloudflare.com/client/v4/zones/{{ cloudflare_zone_id }}/firewall/access_rules/rules?page=1&per_page=1000"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ cloudflare_api_token }}"
+  register: _cf_existing_rules
+  failed_when: _cf_existing_rules.status != 200
+  changed_when: false
+
+- name: Ensure firewall rules are present
+  vars:
+    existing_rules: "{{ _cf_existing_rules.json.result | default([]) }}"
+  loop: "{{ cloudflare_firewall_rules }}"
+  loop_control:
+    loop_var: rule
+  when: >
+    existing_rules | selectattr('configuration.target', 'equalto', rule.target) |
+    selectattr('configuration.value', 'equalto', rule.value) |
+    selectattr('mode', 'equalto', rule.mode) | list | length == 0
+  uri:
+    url: "https://api.cloudflare.com/client/v4/zones/{{ cloudflare_zone_id }}/firewall/access_rules/rules"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ cloudflare_api_token }}"
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      mode: "{{ rule.mode }}"
+      notes: "{{ rule.note }}"
+      configuration:
+        target: "{{ rule.target }}"
+        value: "{{ rule.value }}"
+  register: _create_rule
+  changed_when: _create_rule.status == 200

--- a/src/roles/cloudflare/tasks/main.yml
+++ b/src/roles/cloudflare/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Include Cloudflare DNS tasks
+  import_tasks: dns.yml
+
+- name: Include Cloudflare settings tasks
+  import_tasks: settings.yml
+
+- name: Include Cloudflare firewall tasks
+  import_tasks: firewall.yml

--- a/src/roles/cloudflare/tasks/settings.yml
+++ b/src/roles/cloudflare/tasks/settings.yml
@@ -1,0 +1,26 @@
+---
+- name: Set SSL mode
+  uri:
+    url: "https://api.cloudflare.com/client/v4/zones/{{ cloudflare_zone_id }}/settings/ssl"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ cloudflare_api_token }}"
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      value: "{{ cloudflare_ssl_mode }}"
+  register: _ssl
+  changed_when: _ssl.json.result.value != cloudflare_ssl_mode
+
+- name: Enable / Disable Always Use HTTPS
+  uri:
+    url: "https://api.cloudflare.com/client/v4/zones/{{ cloudflare_zone_id }}/settings/always_use_https"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ cloudflare_api_token }}"
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      value: "{{ 'on' if cloudflare_always_use_https else 'off' }}"
+  register: _https
+  changed_when: _https.json.result.value != ('on' if cloudflare_always_use_https else 'off')

--- a/src/roles/cloudflare/vars/main.yml
+++ b/src/roles/cloudflare/vars/main.yml
@@ -1,0 +1,5 @@
+---
+cloudflare_ssl_mode: "strict"
+cloudflare_always_use_https: true
+cloudflare_dns_records: []
+cloudflare_firewall_rules: []


### PR DESCRIPTION
## Summary
- add ansible config with collections and Cloudflare settings
- add Cloudflare collection requirement
- configure inventory and group vars for Cloudflare
- add Cloudflare role with tasks for dns, settings, firewall
- provide playbook to run Cloudflare role

## Testing
- `ansible-playbook playbooks/cloudflare_setup.yml --syntax-check` *(fails: command not found)*