### PR TITLE
Add OpenLDAP roles and playbooks

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: community.general
+    version: ">=8.2.0"

--- a/src/files/ldap_data.yml
+++ b/src/files/ldap_data.yml
@@ -1,0 +1,22 @@
+---
+base_dn: "dc=example,dc=com"
+
+organizations:
+  - name: Engineering
+    ou: eng
+  - name: Sales
+    ou: sales
+
+users:
+  - uid: jdoe
+    givenName: John
+    sn: Doe
+    mail: jdoe@example.com
+    uidNumber: 2001
+    gidNumber: 2001
+    password: "{SSHA}VGVzdFBhc3N3b3JkIQ=="
+
+groups:
+  - cn: eng
+    description: Engineering Department
+    members: [ jdoe ]

--- a/src/group_vars/all.yml
+++ b/src/group_vars/all.yml
@@ -26,3 +26,6 @@ auto_update_download_updates: yes
 auto_update_apply_updates: no
 auto_update_random_sleep: 360 
 deployment_profile: "simple"
+ldap_data_file: "{{ playbook_dir }}/files/ldap_data.yml"
+ldap_replication: false
+ldap_use_tls: false

--- a/src/inventories/dev/hosts.ini
+++ b/src/inventories/dev/hosts.ini
@@ -1,2 +1,8 @@
 [step_ca_servers]
 ca-dev.local ansible_host=192.168.1.100
+
+[ldap_servers]
+ldap-dev-1 ansible_host=10.1.0.11 ansible_user=ubuntu
+
+[ldap_clients]
+app-dev-1 ansible_host=10.1.0.21 ansible_user=ubuntu

--- a/src/inventories/production/hosts.ini
+++ b/src/inventories/production/hosts.ini
@@ -14,3 +14,15 @@ es-node6 ansible_host=10.0.0.6
 es_master
 es_data
 es_coord
+
+[ldap_servers]
+ldap-prod-1 ansible_host=10.10.0.11 ansible_user=ubuntu
+ldap-prod-2 ansible_host=10.10.0.12 ansible_user=ubuntu
+
+[ldap_clients]
+app-prod-1 ansible_host=10.10.0.21 ansible_user=ubuntu
+app-prod-2 ansible_host=10.10.0.22 ansible_user=ubuntu
+
+[ldap_servers:vars]
+ldap_replication: true
+ldap_use_tls: true

--- a/src/playbooks/ldap-clients.yml
+++ b/src/playbooks/ldap-clients.yml
@@ -1,0 +1,5 @@
+---
+- hosts: ldap_clients
+  become: yes
+  roles:
+    - openldap_client

--- a/src/playbooks/ldap-servers.yml
+++ b/src/playbooks/ldap-servers.yml
@@ -1,0 +1,9 @@
+---
+- hosts: ldap_servers
+  become: yes
+  roles:
+    - openldap_server
+    - openldap_content
+    - { role: openldap_replication, when: ldap_replication }
+    - openldap_logging
+    - openldap_backup

--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -1,9 +1,3 @@
 ---
-- name: Install and configure Elasticsearch cluster
-  hosts: elasticsearch
-  become: yes
-  roles:
-    - role: elasticsearch_install
-    - role: elasticsearch_config
-    - role: elasticsearch_security
-    - role: elasticsearch_snapshot
+- import_playbook: ldap-servers.yml
+- import_playbook: ldap-clients.yml

--- a/src/roles/openldap_backup/tasks/main.yml
+++ b/src/roles/openldap_backup/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Install backup script
+  ansible.builtin.copy:
+    dest: /usr/local/sbin/ldap_backup.sh
+    mode: "0700"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -e
+      BACKUP_DIR=/var/backups/ldap
+      mkdir -p "$BACKUP_DIR"
+      DATE=$(date +'%Y%m%d%H%M')
+      slapcat -b "cn=config" -l "$BACKUP_DIR/config-$DATE.ldif"
+      slapcat -b "{{ ldap_base_dn }}" -l "$BACKUP_DIR/data-$DATE.ldif"
+      tar czf "$BACKUP_DIR/ldap-backup-$DATE.tar.gz" -C "$BACKUP_DIR" "config-$DATE.ldif" "data-$DATE.ldif"
+      rm "$BACKUP_DIR"/config-"$DATE".ldif "$BACKUP_DIR"/data-"$DATE".ldif
+      find "$BACKUP_DIR" -type f -name "ldap-backup-*.tar.gz" -mtime +30 -delete
+
+- name: Schedule nightly backup
+  ansible.builtin.cron:
+    name: "OpenLDAP nightly backup"
+    user: root
+    minute: 0
+    hour: 2
+    job: "/usr/local/sbin/ldap_backup.sh"

--- a/src/roles/openldap_client/handlers/main.yml
+++ b/src/roles/openldap_client/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart sssd
+  ansible.builtin.service:
+    name: sssd
+    state: restarted

--- a/src/roles/openldap_client/tasks/main.yml
+++ b/src/roles/openldap_client/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+- name: Install SSSD and Kerberos client
+  ansible.builtin.apt:
+    name:
+      - sssd
+      - sssd-ldap
+      - libnss-sss
+      - libpam-sss
+      - krb5-user
+    state: present
+    update_cache: yes
+
+- name: Configure krb5.conf
+  ansible.builtin.template:
+    src: krb5.conf.j2
+    dest: /etc/krb5.conf
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Configure sssd.conf
+  ansible.builtin.template:
+    src: sssd.conf.j2
+    dest: /etc/sssd/sssd.conf
+    owner: root
+    group: root
+    mode: "0600"
+  notify: restart sssd
+
+- name: Enable SSSD nsswitch integration
+  ansible.builtin.lineinfile:
+    path: /etc/nsswitch.conf
+    regexp: '^passwd:'
+    line: 'passwd:         compat sss'
+- name: Ensure services started
+  ansible.builtin.service:
+    name: sssd
+    state: started
+    enabled: yes

--- a/src/roles/openldap_client/templates/krb5.conf.j2
+++ b/src/roles/openldap_client/templates/krb5.conf.j2
@@ -1,0 +1,10 @@
+[libdefaults]
+  default_realm = {{ kerberos_realm }}
+  dns_lookup_realm = false
+  dns_lookup_kdc = false
+
+[realms]
+  {{ kerberos_realm }} = {
+    kdc = {{ kerberos_kdc }}
+    admin_server = {{ kerberos_kdc }}
+  }

--- a/src/roles/openldap_client/templates/sssd.conf.j2
+++ b/src/roles/openldap_client/templates/sssd.conf.j2
@@ -1,0 +1,13 @@
+[sssd]
+services = nss, pam
+domains = LDAP
+
+[domain/LDAP]
+id_provider = ldap
+auth_provider = krb5
+ldap_uri = ldap://{{ ldap_servers | join(',') }}
+ldap_search_base = {{ ldap_base_dn }}
+krb5_realm = {{ kerberos_realm }}
+krb5_server = {{ kerberos_kdc }}
+fallback_homedir = /home/%u
+access_provider = simple

--- a/src/roles/openldap_content/tasks/main.yml
+++ b/src/roles/openldap_content/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+- name: Load LDAP data file
+  ansible.builtin.include_vars:
+    file: "{{ ldap_data_file }}"
+    name: ldap_data
+
+- name: Ensure organizational units
+  community.general.ldap_entry:
+    dn: "ou={{ item.ou }},{{ ldap_data.base_dn }}"
+    objectClass:
+      - top
+      - organizationalUnit
+    attributes:
+      ou: "{{ item.ou }}"
+      description: "{{ item.name | default(item.ou) }}"
+    state: present
+    bind_url: "ldapi:///"
+  loop: "{{ ldap_data.organizations }}"
+
+- name: Ensure user entries
+  community.general.ldap_entry:
+    dn: "uid={{ item.uid }},ou=People,{{ ldap_data.base_dn }}"
+    objectClass:
+      - top
+      - inetOrgPerson
+      - posixAccount
+      - organizationalPerson
+      - person
+    attributes:
+      cn: "{{ item.givenName }} {{ item.sn }}"
+      sn: "{{ item.sn }}"
+      givenName: "{{ item.givenName }}"
+      uid: "{{ item.uid }}"
+      uidNumber: "{{ item.uidNumber }}"
+      gidNumber: "{{ item.gidNumber }}"
+      homeDirectory: "/home/{{ item.uid }}"
+      mail: "{{ item.mail }}"
+      userPassword: "{{ item.password }}"
+    state: present
+    bind_dn: "cn=admin,{{ ldap_data.base_dn }}"
+    bind_pw: "{{ ldap_admin_password }}"
+    server_uri: "ldap://localhost"
+  loop: "{{ ldap_data.users }}"
+  when: ldap_data.users is defined

--- a/src/roles/openldap_logging/handlers/main.yml
+++ b/src/roles/openldap_logging/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: restart rsyslog
+  ansible.builtin.service:
+    name: rsyslog
+    state: restarted
+- name: restart filebeat
+  ansible.builtin.service:
+    name: filebeat
+    state: restarted

--- a/src/roles/openldap_logging/tasks/main.yml
+++ b/src/roles/openldap_logging/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Configure rsyslog for ldap
+  ansible.builtin.copy:
+    dest: /etc/rsyslog.d/50-ldap.conf
+    content: |
+      local4.*    /var/log/ldap.log
+  notify: restart rsyslog
+
+- name: Install Filebeat
+  ansible.builtin.apt:
+    name: filebeat
+    state: present
+    update_cache: yes
+
+- name: Deploy Filebeat config
+  ansible.builtin.template:
+    src: filebeat.yml.j2
+    dest: /etc/filebeat/filebeat.yml
+  notify: restart filebeat
+
+- name: Ensure services running
+  ansible.builtin.service:
+    name: "{{ item }}"
+    state: started
+    enabled: yes
+  loop:
+    - rsyslog
+    - filebeat

--- a/src/roles/openldap_logging/templates/filebeat.yml.j2
+++ b/src/roles/openldap_logging/templates/filebeat.yml.j2
@@ -1,0 +1,10 @@
+filebeat.inputs:
+  - type: log
+    paths:
+      - /var/log/ldap.log
+    fields:
+      service: openldap
+    fields_under_root: true
+
+output.logstash:
+  hosts: ["{{ elk_host | default('logstash.example.com:5044') }}"]

--- a/src/roles/openldap_replication/defaults/main.yml
+++ b/src/roles/openldap_replication/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+ldap_replication_provider_uri: "ldap://{{ inventory_hostname }}"
+ldap_replication_bind_dn: "cn=admin,{{ ldap_base_dn }}"
+ldap_replication_bind_pw: "{{ ldap_admin_password }}"

--- a/src/roles/openldap_replication/tasks/main.yml
+++ b/src/roles/openldap_replication/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+- name: Fail if replication disabled
+  ansible.builtin.fail:
+    msg: "Replication role invoked but ldap_replication is false"
+  when: not ldap_replication
+
+- name: Set olcServerID
+  community.general.ldap_attr:
+    dn: "cn=config"
+    attribute: olcServerID
+    values: "{{ ansible_play_hosts_all.index(inventory_hostname) + 1 }} {{ inventory_hostname }}"
+    state: present
+    bind_url: "ldapi:///"
+  notify: restart slapd
+
+- name: Enable syncprov overlay
+  community.general.ldap_entry:
+    dn: "olcOverlay=syncprov,olcDatabase={1}mdb,cn=config"
+    objectClass:
+      - olcOverlayConfig
+      - olcSyncProvConfig
+    attributes:
+      olcOverlay: syncprov
+      olcSpCheckpoint: 100 10
+      olcSpSessionlog: 1000
+    state: present
+    bind_url: "ldapi:///"
+  notify: restart slapd
+
+- name: Configure syncrepl for peers
+  ansible.builtin.template:
+    src: syncrepl.ldif.j2
+    dest: /tmp/syncrepl.ldif
+  run_once: false
+
+- name: Apply syncrepl config
+  ansible.builtin.shell: |
+    ldapmodify -Y EXTERNAL -H ldapi:/// -f /tmp/syncrepl.ldif
+  args:
+    warn: false
+  notify: restart slapd

--- a/src/roles/openldap_replication/templates/syncrepl.ldif.j2
+++ b/src/roles/openldap_replication/templates/syncrepl.ldif.j2
@@ -1,0 +1,9 @@
+dn: olcDatabase={1}mdb,cn=config
+changetype: modify
+replace: olcSyncRepl
+{% for host in groups['ldap_servers'] if host != inventory_hostname %}
+olcSyncRepl: rid={{ '%03d' % loop.index }} provider=ldap://{{ host }} binddn="{{ ldap_replication_bind_dn }}" bindmethod=simple credentials={{ ldap_replication_bind_pw }} searchbase="{{ ldap_base_dn }}" type=refreshAndPersist retry="5 5 300 5" timeout=1
+{% endfor %}
+-
+add: olcMirrorMode
+olcMirrorMode: {{ 'TRUE' if groups['ldap_servers'] | length == 2 else 'FALSE' }}

--- a/src/roles/openldap_server/defaults/main.yml
+++ b/src/roles/openldap_server/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+ldap_domain: "example.com"
+ldap_base_dn: "dc=example,dc=com"
+ldap_organization: "Example Corp"
+ldap_admin_password: "{{ vault_ldap_admin_password }}"
+ldap_use_tls: false
+ldap_tls_cert: "/etc/ldap/ssl/ldap.crt"
+ldap_tls_key: "/etc/ldap/ssl/ldap.key"
+ldap_tls_ca: "/etc/ldap/ssl/ca.crt"
+ldap_log_level: 256        # stats
+ldap_extra_schema: []

--- a/src/roles/openldap_server/handlers/main.yml
+++ b/src/roles/openldap_server/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart slapd
+  ansible.builtin.service:
+    name: slapd
+    state: restarted

--- a/src/roles/openldap_server/tasks/config.yml
+++ b/src/roles/openldap_server/tasks/config.yml
@@ -1,0 +1,13 @@
+---
+- name: Set log level
+  community.general.ldap_attr:
+    dn: "cn=config"
+    attribute: olcLogLevel
+    values: "{{ ldap_log_level }}"
+    state: present
+    bind_url: "ldapi:///"
+  notify: restart slapd
+
+- name: Configure TLS (if enabled)
+  ansible.builtin.include_tasks: tls.yml
+  when: ldap_use_tls

--- a/src/roles/openldap_server/tasks/install.yml
+++ b/src/roles/openldap_server/tasks/install.yml
@@ -1,0 +1,24 @@
+---
+- name: Preseed slapd debconf
+  ansible.builtin.debconf:
+    name: slapd
+    question: "{{ item.question }}"
+    value: "{{ item.value }}"
+    vtype: "{{ item.vtype }}"
+  loop:
+    - { question: "slapd/domain", value: "{{ ldap_domain }}", vtype: "string" }
+    - { question: "slapd/password1", value: "{{ ldap_admin_password }}", vtype: "password" }
+    - { question: "slapd/password2", value: "{{ ldap_admin_password }}", vtype: "password" }
+    - { question: "slapd/no_configuration", value: "false", vtype: "boolean" }
+
+- name: Install OpenLDAP server packages
+  ansible.builtin.apt:
+    name: [ slapd, ldap-utils ]
+    state: present
+    update_cache: yes
+
+- name: Ensure slapd service started
+  ansible.builtin.service:
+    name: slapd
+    state: started
+    enabled: yes

--- a/src/roles/openldap_server/tasks/main.yml
+++ b/src/roles/openldap_server/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- ansible.builtin.import_tasks: install.yml
+- ansible.builtin.import_tasks: config.yml

--- a/src/roles/openldap_server/tasks/tls.yml
+++ b/src/roles/openldap_server/tasks/tls.yml
@@ -1,0 +1,35 @@
+---
+- name: Copy TLS cert
+  ansible.builtin.copy:
+    src: "{{ ldap_tls_cert }}"
+    dest: /etc/ldap/ssl/ldap.crt
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Copy TLS key
+  ansible.builtin.copy:
+    src: "{{ ldap_tls_key }}"
+    dest: /etc/ldap/ssl/ldap.key
+    owner: root
+    group: root
+    mode: "0600"
+
+- name: Copy CA cert
+  ansible.builtin.copy:
+    src: "{{ ldap_tls_ca }}"
+    dest: /etc/ldap/ssl/ca.crt
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Configure slapd TLS settings
+  community.general.ldap_attr:
+    dn: "cn=config"
+    attributes:
+      olcTLSCertificateFile: "/etc/ldap/ssl/ldap.crt"
+      olcTLSCertificateKeyFile: "/etc/ldap/ssl/ldap.key"
+      olcTLSCACertificateFile: "/etc/ldap/ssl/ca.crt"
+    state: present
+    bind_url: "ldapi:///"
+  notify: restart slapd


### PR DESCRIPTION
## Summary
- update inventories with LDAP server/client hosts
- add LDAP defaults to `group_vars/all.yml`
- add OpenLDAP roles for server, client, content, replication, logging and backup
- create playbooks for LDAP servers and clients
- add example LDAP data file and requirement for community.general

## Testing
- `ansible-lint` *(fails: command not found)*