### PR TITLE
Add Prometheus role

### DIFF
--- a/src/roles/prometheus/defaults/main.yml
+++ b/src/roles/prometheus/defaults/main.yml
@@ -1,0 +1,35 @@
+---
+prometheus_version: ""                # Empty string = use distro’s current version
+prometheus_scrape_interval: 60s
+prometheus_evaluation_interval: 60s
+prometheus_retention_time: 30d
+prometheus_data_dir: /var/lib/prometheus
+
+# List of node exporter targets (host:port). Override in inventory/group_vars.
+prometheus_node_targets:
+  - "localhost:9100"
+
+# Additional scrape_configs in raw YAML (list or dict). Empty by default.
+prometheus_additional_scrape_configs: []
+
+# Alertmanager URLs (if any)
+prometheus_alertmanager_urls: []
+
+# External labels (optional)
+prometheus_external_label_monitor: ''
+prometheus_external_label_replica: ''
+
+# Combined alert rules file and default example rule
+prometheus_alert_rules: |
+  groups:
+    - name: example.rules
+      rules:
+        - alert: InstanceDown
+          expr: up == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            description: "{{ $labels.instance }} is down for more than 5 minutes."
+
+prometheus_rules_file: /etc/prometheus/alert.rules

--- a/src/roles/prometheus/handlers/main.yml
+++ b/src/roles/prometheus/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart Prometheus
+  service:
+    name: prometheus
+    state: restarted
+    daemon_reload: yes
+  become: yes

--- a/src/roles/prometheus/meta/main.yml
+++ b/src/roles/prometheus/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  author: your_name
+  description: Install and configure Prometheus on Debian-based systems
+  company: your_company
+  license: MIT
+  min_ansible_version: "2.12"
+  platforms:
+    - name: Debian
+      versions: ["bullseye", "bookworm"]
+    - name: Ubuntu
+      versions: ["focal", "jammy"]
+dependencies: []

--- a/src/roles/prometheus/tasks/configure.yml
+++ b/src/roles/prometheus/tasks/configure.yml
@@ -1,0 +1,46 @@
+---
+- name: Ensure Prometheus data directory exists
+  file:
+    path: "{{ prometheus_data_dir }}"
+    state: directory
+    owner: prometheus
+    group: prometheus
+    mode: '0755'
+  become: yes
+
+- name: Deploy Prometheus configuration
+  template:
+    src: prometheus.yml.j2
+    dest: /etc/prometheus/prometheus.yml
+    owner: root
+    group: prometheus
+    mode: '0644'
+  notify: Restart Prometheus
+  become: yes
+
+- name: Deploy alert rules file
+  template:
+    src: alert_rules.yml.j2
+    dest: "{{ prometheus_rules_file }}"
+    owner: root
+    group: prometheus
+    mode: '0644'
+  notify: Restart Prometheus
+  become: yes
+
+- name: Install systemd unit override
+  template:
+    src: prometheus.service.j2
+    dest: /etc/systemd/system/prometheus.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart Prometheus
+  become: yes
+
+- name: Enable and start Prometheus service
+  service:
+    name: prometheus
+    state: started
+    enabled: yes
+  become: yes

--- a/src/roles/prometheus/tasks/exporters.yml
+++ b/src/roles/prometheus/tasks/exporters.yml
@@ -1,0 +1,8 @@
+---
+- name: Ensure Node Exporter service is enabled and started
+  service:
+    name: prometheus-node-exporter
+    state: started
+    enabled: yes
+  become: yes
+  tags: exporters

--- a/src/roles/prometheus/tasks/install.yml
+++ b/src/roles/prometheus/tasks/install.yml
@@ -1,0 +1,14 @@
+---
+- name: Update apt cache
+  apt:
+    update_cache: yes
+  become: yes
+
+- name: Install Prometheus and Node Exporter
+  apt:
+    name:
+      - prometheus
+      - prometheus-node-exporter
+    state: present
+  become: yes
+  tags: install

--- a/src/roles/prometheus/tasks/main.yml
+++ b/src/roles/prometheus/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- import_tasks: install.yml
+- import_tasks: configure.yml
+- import_tasks: exporters.yml

--- a/src/roles/prometheus/templates/alert_rules.yml.j2
+++ b/src/roles/prometheus/templates/alert_rules.yml.j2
@@ -1,0 +1,2 @@
+# Managed by Ansible: /etc/prometheus/alert.rules
+{{ prometheus_alert_rules }}

--- a/src/roles/prometheus/templates/prometheus.service.j2
+++ b/src/roles/prometheus/templates/prometheus.service.j2
@@ -1,0 +1,24 @@
+[Unit]
+Description=Prometheus Server
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=prometheus
+Group=prometheus
+Type=simple
+ExecStart=/usr/bin/prometheus \
+          --config.file=/etc/prometheus/prometheus.yml \
+          --storage.tsdb.path={{ prometheus_data_dir }} \
+          --storage.tsdb.retention.time={{ prometheus_retention_time }} \
+          --web.listen-address=0.0.0.0:9090
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=600s
+LimitNOFILE=65535
+LimitNPROC=4096
+ProtectHome=yes
+ProtectSystem=full
+
+[Install]
+WantedBy=multi-user.target

--- a/src/roles/prometheus/templates/prometheus.yml.j2
+++ b/src/roles/prometheus/templates/prometheus.yml.j2
@@ -1,0 +1,35 @@
+# Managed by Ansible: /etc/prometheus/prometheus.yml
+
+global:
+  scrape_interval: {{ prometheus_scrape_interval }}
+  evaluation_interval: {{ prometheus_evaluation_interval }}
+
+{% if prometheus_alertmanager_urls %}
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: {{ prometheus_alertmanager_urls | to_json }}
+{% endif %}
+
+{% if prometheus_external_label_monitor or prometheus_external_label_replica %}
+external_labels:
+  {% if prometheus_external_label_monitor %}monitor: "{{ prometheus_external_label_monitor }}"{% endif %}
+  {% if prometheus_external_label_replica %}replica: "{{ prometheus_external_label_replica }}"{% endif %}
+{% endif %}
+
+rule_files:
+  - "{{ prometheus_rules_file }}"
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'node_exporter'
+    static_configs:
+      - targets: {{ prometheus_node_targets | to_nice_yaml(indent=10) }}
+
+{% if prometheus_additional_scrape_configs %}
+# Additional user-provided scrape configs
+{{ prometheus_additional_scrape_configs | indent(2) }}
+{% endif %}


### PR DESCRIPTION
## Summary
- add Prometheus role with default vars
- configure handlers and tasks for installation and service management
- template Prometheus configuration files and systemd unit

## Testing
- `ansible-lint -v src/roles/prometheus` *(fails: command not found)*