### PR TITLE
Add MinIO role

### DIFF
--- a/src/roles/minio/defaults/main.yml
+++ b/src/roles/minio/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+minio_version: "RELEASE.2025-05-05T00-00-00Z"
+minio_download_url: "https://dl.min.io/server/minio/release/linux-amd64/minio"
+minio_binary_path: "/usr/local/bin/minio"
+
+minio_user: "minio"
+minio_group: "minio"
+
+minio_base_dir: "/opt/minio"
+minio_data_dir: "{{ minio_base_dir }}/data"
+
+minio_root_user: "minioadmin"
+minio_root_password: "minioadmin"
+
+minio_server_port: 9000
+minio_console_port: 9001
+
+minio_enable_tls: true
+minio_self_signed: false
+minio_domain: "{{ inventory_hostname }}"
+minio_extra_sans: []
+
+minio_cert_public: ""
+minio_cert_private: ""
+minio_certs_dir: "{{ minio_base_dir }}/certs"
+
+minio_volumes: "{{ minio_data_dir }}"
+
+minio_opts_extra: "--console-address :{{ minio_console_port }}"

--- a/src/roles/minio/handlers/main.yml
+++ b/src/roles/minio/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: daemon-reload
+  ansible.builtin.systemd:
+    daemon_reload: yes
+
+- name: restart minio
+  ansible.builtin.service:
+    name: minio
+    state: restarted

--- a/src/roles/minio/meta/main.yml
+++ b/src/roles/minio/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: minio_systemd
+  description: Install and configure MinIO object storage as a systemd service on Debian
+  author: Your Name
+  license: MIT
+  min_ansible_version: "2.12"
+  platforms:
+    - name: Debian
+      versions:
+        - bullseye
+        - bookworm
+  galaxy_tags:
+    - storage
+    - objectstorage
+    - minio
+    - systemd
+dependencies: []

--- a/src/roles/minio/tasks/config.yml
+++ b/src/roles/minio/tasks/config.yml
@@ -1,0 +1,14 @@
+---
+- name: Set minio_opts fact
+  ansible.builtin.set_fact:
+    minio_opts: >-
+      {{ minio_opts_extra }}{% if minio_enable_tls %} --certs-dir {{ minio_certs_dir }}{% endif %}
+
+- name: Template environment file
+  ansible.builtin.template:
+    src: minio.env.j2
+    dest: /etc/default/minio
+    owner: root
+    group: root
+    mode: "0640"
+  notify: restart minio

--- a/src/roles/minio/tasks/install.yml
+++ b/src/roles/minio/tasks/install.yml
@@ -1,0 +1,35 @@
+---
+- name: Ensure minio group exists
+  ansible.builtin.group:
+    name: "{{ minio_group }}"
+    state: present
+
+- name: Ensure minio user exists
+  ansible.builtin.user:
+    name: "{{ minio_user }}"
+    group: "{{ minio_group }}"
+    home: "{{ minio_base_dir }}"
+    shell: /usr/sbin/nologin
+    system: yes
+    create_home: no
+    state: present
+
+- name: Create base and data directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ minio_user }}"
+    group: "{{ minio_group }}"
+    mode: "0755"
+  loop:
+    - "{{ minio_base_dir }}"
+    - "{{ minio_data_dir }}"
+    - "{{ minio_certs_dir }}"
+
+- name: Download MinIO binary
+  ansible.builtin.get_url:
+    url: "{{ minio_download_url }}"
+    dest: "{{ minio_binary_path }}"
+    mode: "0755"
+    owner: root
+    group: root

--- a/src/roles/minio/tasks/main.yml
+++ b/src/roles/minio/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Include OS specific vars
+  include_vars: "{{ ansible_os_family }}.yml"
+  when: ansible_os_family is defined
+
+- name: Install prerequisite packages
+  ansible.builtin.package:
+    name: "{{ minio_required_packages }}"
+    state: present
+
+- name: Include installation tasks
+  import_tasks: install.yml
+
+- name: Include configuration tasks
+  import_tasks: config.yml
+
+- name: Include TLS tasks
+  import_tasks: tls.yml
+  when: minio_enable_tls
+
+- name: Include service tasks
+  import_tasks: service.yml

--- a/src/roles/minio/tasks/service.yml
+++ b/src/roles/minio/tasks/service.yml
@@ -1,0 +1,17 @@
+---
+- name: Template systemd unit
+  ansible.builtin.template:
+    src: minio.service.j2
+    dest: /etc/systemd/system/minio.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - daemon-reload
+    - restart minio
+
+- name: Ensure minio service enabled and started
+  ansible.builtin.service:
+    name: minio
+    enabled: yes
+    state: started

--- a/src/roles/minio/tasks/tls.yml
+++ b/src/roles/minio/tasks/tls.yml
@@ -1,0 +1,53 @@
+---
+- name: Ensure cert dir exists
+  ansible.builtin.file:
+    path: "{{ minio_certs_dir }}"
+    state: directory
+    owner: "{{ minio_user }}"
+    group: "{{ minio_group }}"
+    mode: "0755"
+
+- name: Copy provided certificates
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "{{ minio_certs_dir }}/{{ item.dest }}"
+    owner: "{{ minio_user }}"
+    group: "{{ minio_group }}"
+    mode: "0640"
+  loop:
+    - { src: "{{ minio_cert_public }}", dest: "public.crt" }
+    - { src: "{{ minio_cert_private }}", dest: "private.key" }
+  when: minio_cert_public | length > 0 and minio_cert_private | length > 0
+
+- name: Generate self-signed certificate
+  block:
+    - name: Generate private key
+      community.crypto.openssl_privatekey:
+        path: "{{ minio_certs_dir }}/private.key"
+        owner: "{{ minio_user }}"
+        group: "{{ minio_group }}"
+        mode: "0600"
+
+    - name: Generate CSR
+      community.crypto.openssl_csr:
+        path: "{{ minio_certs_dir }}/request.csr"
+        privatekey_path: "{{ minio_certs_dir }}/private.key"
+        common_name: "{{ minio_domain }}"
+        subject_alt_name: >-
+          {{ ['DNS:' + minio_domain] + minio_extra_sans | default([]) | map('regex_replace','^(.*)$','DNS:\1') | list }}
+        owner: "{{ minio_user }}"
+        group: "{{ minio_group }}"
+        mode: "0600"
+
+    - name: Generate self-signed cert
+      community.crypto.openssl_certificate:
+        path: "{{ minio_certs_dir }}/public.crt"
+        privatekey_path: "{{ minio_certs_dir }}/private.key"
+        csr_path: "{{ minio_certs_dir }}/request.csr"
+        provider: selfsigned
+        days: 365
+        owner: "{{ minio_user }}"
+        group: "{{ minio_group }}"
+        mode: "0644"
+  when: minio_self_signed and (minio_cert_public | length == 0 or minio_cert_private | length == 0)
+  notify: restart minio

--- a/src/roles/minio/templates/minio.env.j2
+++ b/src/roles/minio/templates/minio.env.j2
@@ -1,0 +1,4 @@
+MINIO_ROOT_USER="{{ minio_root_user }}"
+MINIO_ROOT_PASSWORD="{{ minio_root_password }}"
+MINIO_VOLUMES="{{ minio_volumes }}"
+MINIO_OPTS="{{ minio_opts }}"

--- a/src/roles/minio/templates/minio.service.j2
+++ b/src/roles/minio/templates/minio.service.j2
@@ -1,0 +1,23 @@
+[Unit]
+Description=MinIO Object Storage
+Documentation=https://docs.min.io
+Wants=network-online.target
+After=network-online.target
+
+AssertFileIsExecutable={{ minio_binary_path }}
+
+[Service]
+User={{ minio_user }}
+Group={{ minio_group }}
+EnvironmentFile=-/etc/default/minio
+WorkingDirectory={{ minio_base_dir }}
+ExecStartPre=/bin/sh -c 'if [ -z "$MINIO_VOLUMES" ]; then echo "ERROR: MINIO_VOLUMES is not set"; exit 1; fi'
+ExecStart={{ minio_binary_path }} server $MINIO_OPTS $MINIO_VOLUMES
+Restart=always
+LimitNOFILE=65536
+TasksMax=infinity
+TimeoutStopSec=infinity
+SendSIGKILL=no
+
+[Install]
+WantedBy=multi-user.target

--- a/src/roles/minio/vars/Debian.yml
+++ b/src/roles/minio/vars/Debian.yml
@@ -1,0 +1,4 @@
+---
+minio_required_packages:
+  - curl
+  - openssl


### PR DESCRIPTION
## Summary
- add defaults for MinIO configuration
- add Debian vars and handlers
- add tasks for install, config, tls, service
- add service unit and env templates
- define role metadata

## Testing
- `git status --short`