### PR TITLE
Add Apache NiFi role

### DIFF
--- a/src/group_vars/all.yml
+++ b/src/group_vars/all.yml
@@ -34,3 +34,4 @@ es_heap_size: "4g"
 metadata_api_base: "http://10.0.0.20:5002"
 search_api_base: "http://10.0.0.21:5001"
 
+ansible_python_interpreter: /usr/bin/python3

--- a/src/group_vars/nifi_nodes.yml
+++ b/src/group_vars/nifi_nodes.yml
@@ -1,0 +1,5 @@
+---
+nifi_heap_size: "8g"
+nifi_enable_elk: true
+elk_logstash_host: "logstash.prod.internal"
+elk_logstash_port: 5044

--- a/src/inventories/production/hosts
+++ b/src/inventories/production/hosts
@@ -1,2 +1,15 @@
 [cloudflare]
 localhost ansible_connection=local
+
+[nifi_single]
+nifi-dev.example.com
+
+[nifi_nodes]
+nifi1.example.com
+nifi2.example.com
+nifi3.example.com
+
+[zookeeper_nodes]
+zk1.example.com
+zk2.example.com
+zk3.example.com

--- a/src/playbooks/nifi-cluster.yml
+++ b/src/playbooks/nifi-cluster.yml
@@ -1,0 +1,14 @@
+---
+- hosts: nifi_nodes
+  become: yes
+  vars:
+    nifi_cluster_enable: true
+    nifi_cluster_nodes: "{{ groups['nifi_nodes'] }}"
+    nifi_zookeeper_connect: "{{ groups['zookeeper_nodes'] | map('regex_replace', '(.*)', '\\1:2181') | join(',') }}"
+    nifi_tls_toolkit_enable: true
+    nifi_security_mode: ssl
+    nifi_initial_admin_identity: "CN=NiFi Admin, OU=IT, O=Example Corp, C=US"
+    nifi_keystore_password: "changeit"
+    nifi_truststore_password: "changeit"
+  roles:
+    - apache_nifi

--- a/src/playbooks/nifi-single.yml
+++ b/src/playbooks/nifi-single.yml
@@ -1,0 +1,11 @@
+---
+- hosts: nifi_single
+  become: yes
+  vars:
+    nifi_cluster_enable: false
+    nifi_security_mode: ssl
+    nifi_initial_admin_identity: "CN=NiFi Admin, OU=IT, O=Example Corp, C=US"
+    nifi_keystore_password: "changeit"
+    nifi_truststore_password: "changeit"
+  roles:
+    - apache_nifi

--- a/src/roles/apache_nifi/defaults/main.yml
+++ b/src/roles/apache_nifi/defaults/main.yml
@@ -1,0 +1,40 @@
+---
+nifi_version: "2.4.0"
+nifi_download_url: "https://downloads.apache.org/nifi/{{ nifi_version }}/nifi-{{ nifi_version }}-bin.tar.gz"
+
+# Installation
+nifi_install_dir: "/opt"
+nifi_user: "nifi"
+nifi_group: "nifi"
+nifi_home: "{{ nifi_install_dir }}/nifi-{{ nifi_version }}"
+nifi_current_link: "/opt/nifi"
+nifi_java_package: "openjdk-17-jdk"
+
+# Runtime
+nifi_heap_size: "4g"
+
+# Security
+nifi_security_mode: "ssl"        # ssl | http
+nifi_keystore_path: "{{ nifi_home }}/conf/keystore.jks"
+nifi_keystore_password: ""
+nifi_key_password: "{{ nifi_keystore_password }}"
+nifi_truststore_path: "{{ nifi_home }}/conf/truststore.jks"
+nifi_truststore_password: ""
+nifi_initial_admin_identity: ""
+nifi_admin_username: "admin"
+nifi_admin_password: "admin123"  # vault in production
+
+# TLS Toolkit
+nifi_tls_toolkit_enable: false
+nifi_tls_toolkit_url: "https://downloads.apache.org/nifi/{{ nifi_version }}/nifi-toolkit-{{ nifi_version }}-bin.zip"
+nifi_ca_server: ""
+
+# Clustering
+nifi_cluster_enable: false
+nifi_cluster_nodes: []
+nifi_zookeeper_connect: ""
+
+# ELK integration
+nifi_enable_elk: false
+elk_logstash_host: ""
+elk_logstash_port: 5044

--- a/src/roles/apache_nifi/handlers/main.yml
+++ b/src/roles/apache_nifi/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart nifi
+  ansible.builtin.systemd:
+    name: nifi
+    state: restarted
+    daemon_reload: yes

--- a/src/roles/apache_nifi/meta/main.yml
+++ b/src/roles/apache_nifi/meta/main.yml
@@ -1,0 +1,11 @@
+---
+galaxy_info:
+  role_name: apache_nifi
+  author: your_name
+  description: Install and configure Apache NiFi (single-node or cluster) on Debian systems.
+  license: Apache-2.0
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions: ["11", "12"]
+dependencies: []

--- a/src/roles/apache_nifi/tasks/cluster.yml
+++ b/src/roles/apache_nifi/tasks/cluster.yml
@@ -1,0 +1,15 @@
+---
+- name: Ensure cluster properties set
+  ansible.builtin.lineinfile:
+    path: "{{ nifi_home }}/conf/nifi.properties"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    owner: "{{ nifi_user }}"
+    group: "{{ nifi_group }}"
+    mode: "0640"
+  loop:
+    - { regexp: '^nifi.cluster.is.node=.*',          line: 'nifi.cluster.is.node=true' }
+    - { regexp: '^nifi.cluster.node.address=.*',    line: 'nifi.cluster.node.address={{ ansible_fqdn }}' }
+    - { regexp: '^nifi.cluster.node.protocol.port=.*', line: 'nifi.cluster.node.protocol.port=11443' }
+    - { regexp: '^nifi.zookeeper.connect.string=.*', line: 'nifi.zookeeper.connect.string={{ nifi_zookeeper_connect }}' }
+  notify: restart nifi

--- a/src/roles/apache_nifi/tasks/configure.yml
+++ b/src/roles/apache_nifi/tasks/configure.yml
@@ -1,0 +1,29 @@
+---
+- name: Configure nifi.properties
+  ansible.builtin.template:
+    src: nifi.properties.j2
+    dest: "{{ nifi_home }}/conf/nifi.properties"
+    owner: "{{ nifi_user }}"
+    group: "{{ nifi_group }}"
+    mode: "0640"
+  notify: restart nifi
+
+- name: Configure authorizers.xml
+  ansible.builtin.template:
+    src: authorizers.xml.j2
+    dest: "{{ nifi_home }}/conf/authorizers.xml"
+    owner: "{{ nifi_user }}"
+    group: "{{ nifi_group }}"
+    mode: "0640"
+  when: nifi_security_mode == 'ssl'
+  notify: restart nifi
+
+- name: Configure logback.xml
+  ansible.builtin.template:
+    src: logback.xml.j2
+    dest: "{{ nifi_home }}/conf/logback.xml"
+    owner: "{{ nifi_user }}"
+    group: "{{ nifi_group }}"
+    mode: "0640"
+  when: nifi_enable_elk | bool
+  notify: restart nifi

--- a/src/roles/apache_nifi/tasks/elk.yml
+++ b/src/roles/apache_nifi/tasks/elk.yml
@@ -1,0 +1,29 @@
+---
+- name: Install Filebeat
+  ansible.builtin.apt:
+    name: filebeat
+    state: present
+    update_cache: yes
+
+- name: Configure Filebeat for NiFi logs
+  ansible.builtin.copy:
+    dest: /etc/filebeat/filebeat.yml
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      filebeat.inputs:
+        - type: log
+          enabled: true
+          paths:
+            - "{{ nifi_home }}/logs/*.log"
+
+      output.logstash:
+        hosts: ["{{ elk_logstash_host }}:{{ elk_logstash_port }}"]
+  notify: restart filebeat
+
+- name: Enable and start Filebeat
+  ansible.builtin.systemd:
+    name: filebeat
+    state: started
+    enabled: yes

--- a/src/roles/apache_nifi/tasks/install.yml
+++ b/src/roles/apache_nifi/tasks/install.yml
@@ -1,0 +1,71 @@
+---
+- name: Install prerequisites
+  ansible.builtin.apt:
+    name: "{{ nifi_java_package }}"
+    state: present
+    update_cache: yes
+
+- name: Create nifi group
+  ansible.builtin.group:
+    name: "{{ nifi_group }}"
+    state: present
+
+- name: Create nifi user
+  ansible.builtin.user:
+    name: "{{ nifi_user }}"
+    group: "{{ nifi_group }}"
+    shell: /usr/sbin/nologin
+    system: yes
+    create_home: no
+    state: present
+
+- name: Download Apache NiFi tarball
+  ansible.builtin.get_url:
+    url: "{{ nifi_download_url }}"
+    dest: "/tmp/nifi-{{ nifi_version }}.tar.gz"
+    mode: "0644"
+    force: no
+
+- name: Extract NiFi
+  ansible.builtin.unarchive:
+    src: "/tmp/nifi-{{ nifi_version }}.tar.gz"
+    dest: "{{ nifi_install_dir }}"
+    remote_src: yes
+    creates: "{{ nifi_home }}"
+
+- name: Create current symlink
+  ansible.builtin.file:
+    src: "{{ nifi_home }}"
+    dest: "{{ nifi_current_link }}"
+    state: link
+
+- name: Fix ownership
+  ansible.builtin.file:
+    path: "{{ item }}"
+    owner: "{{ nifi_user }}"
+    group: "{{ nifi_group }}"
+    recurse: yes
+  loop:
+    - "{{ nifi_home }}"
+
+- name: Install systemd unit
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/nifi.service
+    content: |
+      [Unit]
+      Description=Apache NiFi
+      After=network.target
+
+      [Service]
+      Type=forking
+      User={{ nifi_user }}
+      Group={{ nifi_group }}
+      ExecStart={{ nifi_current_link }}/bin/nifi.sh start
+      ExecStop={{ nifi_current_link }}/bin/nifi.sh stop
+      Restart=on-failure
+      SuccessExitStatus=143
+
+      [Install]
+      WantedBy=multi-user.target
+    mode: "0644"
+  notify: restart nifi

--- a/src/roles/apache_nifi/tasks/main.yml
+++ b/src/roles/apache_nifi/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- import_tasks: install.yml
+- import_tasks: configure.yml
+- import_tasks: users.yml
+- import_tasks: cluster.yml
+  when: nifi_cluster_enable | bool
+- import_tasks: elk.yml
+  when: nifi_enable_elk | bool
+
+- name: enable and start nifi service
+  ansible.builtin.systemd:
+    name: nifi
+    state: started
+    enabled: yes

--- a/src/roles/apache_nifi/tasks/users.yml
+++ b/src/roles/apache_nifi/tasks/users.yml
@@ -1,0 +1,11 @@
+---
+- name: Ensure initial admin is set
+  ansible.builtin.lineinfile:
+    path: "{{ nifi_home }}/conf/authorizers.xml"
+    regexp: '<property name="Initial Admin Identity">.*</property>'
+    line: '<property name="Initial Admin Identity">{{ nifi_initial_admin_identity }}</property>'
+    owner: "{{ nifi_user }}"
+    group: "{{ nifi_group }}"
+    mode: "0640"
+  when: nifi_security_mode == 'ssl' and nifi_initial_admin_identity != ''
+  notify: restart nifi

--- a/src/roles/apache_nifi/templates/authorizers.xml.j2
+++ b/src/roles/apache_nifi/templates/authorizers.xml.j2
@@ -1,0 +1,11 @@
+<authorizers>
+  <authorizer>
+    <identifier>file-provider</identifier>
+    <class>org.apache.nifi.authorization.FileAuthorizer</class>
+    <property name="Authorizations File">./conf/authorizations.xml</property>
+    <property name="Users File">./conf/users.xml</property>
+    <property name="Initial Admin Identity">{{ nifi_initial_admin_identity }}</property>
+    <property name="Legacy Authorized Users File"></property>
+    <property name="Node Identity 1"></property>
+  </authorizer>
+</authorizers>

--- a/src/roles/apache_nifi/templates/logback.xml.j2
+++ b/src/roles/apache_nifi/templates/logback.xml.j2
@@ -1,0 +1,16 @@
+<configuration>
+  <include resource="org/apache/nifi/logback-common.xml"/>
+  <appender name="ELK" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>{{ nifi_home }}/logs/nifi-elk.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>{{ nifi_home }}/logs/nifi-elk-%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%date{ISO8601} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="ELK"/>
+  </root>
+</configuration>

--- a/src/roles/apache_nifi/templates/nifi.properties.j2
+++ b/src/roles/apache_nifi/templates/nifi.properties.j2
@@ -1,0 +1,26 @@
+nifi.web.http.host=
+{% if nifi_security_mode == 'ssl' %}
+nifi.web.https.host={{ ansible_fqdn }}
+nifi.web.https.port=9443
+nifi.security.keystore={{ nifi_keystore_path }}
+nifi.security.keystoreType=JKS
+nifi.security.keystorePasswd={{ nifi_keystore_password }}
+nifi.security.keyPasswd={{ nifi_key_password }}
+nifi.security.truststore={{ nifi_truststore_path }}
+nifi.security.truststoreType=JKS
+nifi.security.truststorePasswd={{ nifi_truststore_password }}
+nifi.security.allow.anonymous.authentication=false
+{% else %}
+nifi.web.http.port=8080
+{% endif %}
+nifi.remote.input.socket.port=10000
+nifi.remote.input.secure={{ 'true' if nifi_security_mode == 'ssl' else 'false' }}
+nifi.flow.configuration.archive.enabled=true
+nifi.flow.configuration.archive.max.time=30 days
+nifi.flow.configuration.archive.max.storage=500 MB
+nifi.cluster.is.node={{ 'true' if nifi_cluster_enable else 'false' }}
+{% if nifi_cluster_enable %}
+nifi.cluster.node.address={{ ansible_fqdn }}
+nifi.cluster.node.protocol.port=11443
+nifi.zookeeper.connect.string={{ nifi_zookeeper_connect }}
+{% endif %}


### PR DESCRIPTION
## Summary
- add `apache_nifi` role with tasks, handlers, and templates
- add playbooks for single and clustered NiFi deployment
- add inventory groups and group variables for NiFi
- configure Python interpreter for all hosts

## Testing
- `git status --short`
