### PR TITLE
Add Apache Superset role

### DIFF
--- a/src/roles/apache_superset/README.md
+++ b/src/roles/apache_superset/README.md
@@ -1,0 +1,23 @@
+# Ansible Role: Apache Superset
+
+Installs and configures Apache Superset. This role manages installation packages and service configuration required to run Apache Superset on a host.
+
+## Requirements
+
+None.
+
+## Role Variables
+
+See `defaults/main.yml` for a full list of variables that can be overridden.
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```yaml
+- hosts: superset
+  roles:
+    - role: apache_superset
+```

--- a/src/roles/apache_superset/defaults/main.yml
+++ b/src/roles/apache_superset/defaults/main.yml
@@ -1,0 +1,46 @@
+---
+superset_version: "latest"
+
+superset_user: "superset"
+superset_group: "superset"
+
+superset_install_dir: "/opt/superset"
+superset_venv_dir: "{{ superset_install_dir }}/venv"
+superset_config_dir: "/etc/superset"
+superset_config_path: "{{ superset_config_dir }}/superset_config.py"
+
+superset_system_packages:
+  - build-essential
+  - libssl-dev
+  - libffi-dev
+  - python3-dev
+  - python3-pip
+  - libsasl2-dev
+  - libldap2-dev
+  - default-libmysqlclient-dev
+  - libpq-dev
+
+superset_additional_python_packages: []  # e.g. ['psycopg2-binary', 'mysqlclient']
+
+superset_database_uri: "sqlite:////{{ superset_install_dir }}/superset.db"
+
+superset_secret_key: "CHANGEME"  # override via vault
+superset_admin_username: "admin"  # override via vault
+superset_admin_password: "CHANGEME"  # override via vault
+superset_admin_email: "admin@example.com"
+superset_admin_firstname: "Superset"
+superset_admin_lastname: "Admin"
+
+superset_load_examples: false
+superset_use_gunicorn: true
+superset_gunicorn_workers: 4
+superset_gunicorn_bind: "0.0.0.0:8088"
+
+superset_redis_url: ""
+superset_celery_broker_url: ""
+
+superset_feature_flags: {}
+
+superset_service_name: "superset"
+
+superset_marker_file: "{{ superset_config_dir }}/.admin_created"

--- a/src/roles/apache_superset/defaults/superset_config.yml
+++ b/src/roles/apache_superset/defaults/superset_config.yml
@@ -1,0 +1,3 @@
+---
+WTF_CSRF_ENABLED: true
+FEATURE_FLAGS: "{{ superset_feature_flags }}"

--- a/src/roles/apache_superset/handlers/main.yml
+++ b/src/roles/apache_superset/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart superset
+  ansible.builtin.systemd:
+    name: "{{ superset_service_name }}"
+    state: restarted
+    daemon_reload: yes

--- a/src/roles/apache_superset/meta/main.yml
+++ b/src/roles/apache_superset/meta/main.yml
@@ -1,0 +1,11 @@
+---
+galaxy_info:
+  role_name: apache_superset
+  author: "Your Name"
+  description: "Deploy Apache Superset on Debian-based systems"
+  license: "MIT"
+  min_ansible_version: "2.12"
+  platforms:
+    - name: Debian
+      versions: ["bullseye", "bookworm"]
+dependencies: []

--- a/src/roles/apache_superset/tasks/config.yml
+++ b/src/roles/apache_superset/tasks/config.yml
@@ -1,0 +1,17 @@
+---
+- name: Ensure configuration directory exists
+  ansible.builtin.file:
+    path: "{{ superset_config_dir }}"
+    state: directory
+    owner: "{{ superset_user }}"
+    group: "{{ superset_group }}"
+    mode: "0750"
+
+- name: Render Superset configuration
+  ansible.builtin.template:
+    src: superset_config.py.j2
+    dest: "{{ superset_config_path }}"
+    owner: "{{ superset_user }}"
+    group: "{{ superset_group }}"
+    mode: "0640"
+  notify: restart superset

--- a/src/roles/apache_superset/tasks/init_db.yml
+++ b/src/roles/apache_superset/tasks/init_db.yml
@@ -1,0 +1,48 @@
+---
+- name: Run database migrations
+  ansible.builtin.command: "{{ superset_venv_dir }}/bin/superset db upgrade"
+  environment:
+    FLASK_APP: superset
+    SUPERSET_CONFIG_PATH: "{{ superset_config_path }}"
+  changed_when: false
+  become_user: "{{ superset_user }}"
+
+- name: Create admin user
+  ansible.builtin.command: >
+    {{ superset_venv_dir }}/bin/superset fab create-admin
+    --username "{{ superset_admin_username }}"
+    --firstname "{{ superset_admin_firstname }}"
+    --lastname "{{ superset_admin_lastname }}"
+    --email "{{ superset_admin_email }}"
+    --password "{{ superset_admin_password }}"
+  args:
+    creates: "{{ superset_marker_file }}"
+  environment:
+    FLASK_APP: superset
+    SUPERSET_CONFIG_PATH: "{{ superset_config_path }}"
+  become_user: "{{ superset_user }}"
+
+- name: Touch marker file after admin creation
+  ansible.builtin.file:
+    path: "{{ superset_marker_file }}"
+    state: touch
+    owner: "{{ superset_user }}"
+    group: "{{ superset_group }}"
+  when: not (superset_marker_file is exists)
+  become: yes
+
+- name: Load example data
+  ansible.builtin.command: "{{ superset_venv_dir }}/bin/superset load_examples"
+  environment:
+    FLASK_APP: superset
+    SUPERSET_CONFIG_PATH: "{{ superset_config_path }}"
+  when: superset_load_examples | bool
+  become_user: "{{ superset_user }}"
+
+- name: Initialize roles and permissions
+  ansible.builtin.command: "{{ superset_venv_dir }}/bin/superset init"
+  environment:
+    FLASK_APP: superset
+    SUPERSET_CONFIG_PATH: "{{ superset_config_path }}"
+  changed_when: false
+  become_user: "{{ superset_user }}"

--- a/src/roles/apache_superset/tasks/install.yml
+++ b/src/roles/apache_superset/tasks/install.yml
@@ -1,0 +1,20 @@
+---
+- name: Ensure superset group exists
+  ansible.builtin.group:
+    name: "{{ superset_group }}"
+    state: present
+
+- name: Ensure superset user exists
+  ansible.builtin.user:
+    name: "{{ superset_user }}"
+    group: "{{ superset_group }}"
+    create_home: no
+    shell: /usr/sbin/nologin
+    state: present
+
+- name: Install system dependencies
+  ansible.builtin.apt:
+    name: "{{ superset_system_packages }}"
+    state: present
+    update_cache: yes
+  become: yes

--- a/src/roles/apache_superset/tasks/main.yml
+++ b/src/roles/apache_superset/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Include install tasks
+  ansible.builtin.import_tasks: install.yml
+  tags: ['superset', 'superset_install']
+
+- name: Include venv setup tasks
+  ansible.builtin.import_tasks: setup_venv.yml
+  tags: ['superset', 'superset_venv']
+
+- name: Include configuration tasks
+  ansible.builtin.import_tasks: config.yml
+  tags: ['superset', 'superset_config']
+
+- name: Include database initialization tasks
+  ansible.builtin.import_tasks: init_db.yml
+  tags: ['superset', 'superset_db']
+
+- name: Include service tasks
+  ansible.builtin.import_tasks: service.yml
+  tags: ['superset', 'superset_service']

--- a/src/roles/apache_superset/tasks/service.yml
+++ b/src/roles/apache_superset/tasks/service.yml
@@ -1,0 +1,20 @@
+---
+- name: Render Superset systemd unit
+  ansible.builtin.template:
+    src: superset.service.j2
+    dest: "/etc/systemd/system/{{ superset_service_name }}.service"
+    mode: "0644"
+  notify: restart superset
+  become: yes
+
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: yes
+  become: yes
+
+- name: Enable and start Superset service
+  ansible.builtin.systemd:
+    name: "{{ superset_service_name }}"
+    enabled: yes
+    state: started
+  become: yes

--- a/src/roles/apache_superset/tasks/setup_venv.yml
+++ b/src/roles/apache_superset/tasks/setup_venv.yml
@@ -1,0 +1,38 @@
+---
+- name: Create installation directory
+  ansible.builtin.file:
+    path: "{{ superset_install_dir }}"
+    state: directory
+    owner: "{{ superset_user }}"
+    group: "{{ superset_group }}"
+    mode: "0755"
+
+- name: Create virtualenv
+  ansible.builtin.command: python3 -m venv "{{ superset_venv_dir }}"
+  args:
+    creates: "{{ superset_venv_dir }}/bin/activate"
+  become_user: "{{ superset_user }}"
+
+- name: Upgrade pip and setuptools
+  ansible.builtin.pip:
+    virtualenv: "{{ superset_venv_dir }}"
+    name:
+      - pip
+      - setuptools
+    state: latest
+  become_user: "{{ superset_user }}"
+
+- name: Install Superset
+  ansible.builtin.pip:
+    virtualenv: "{{ superset_venv_dir }}"
+    name: "apache-superset=={{ superset_version }}"
+    state: present
+  become_user: "{{ superset_user }}"
+
+- name: Install additional Python packages
+  ansible.builtin.pip:
+    virtualenv: "{{ superset_venv_dir }}"
+    name: "{{ superset_additional_python_packages }}"
+    state: present
+  when: superset_additional_python_packages | length > 0
+  become_user: "{{ superset_user }}"

--- a/src/roles/apache_superset/templates/superset-worker.service.j2
+++ b/src/roles/apache_superset/templates/superset-worker.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Apache Superset Celery Worker
+After=network.target
+
+[Service]
+Type=simple
+User={{ superset_user }}
+Group={{ superset_group }}
+WorkingDirectory={{ superset_install_dir }}
+Environment=SUPERSET_CONFIG_PATH={{ superset_config_path }}
+ExecStart={{ superset_venv_dir }}/bin/celery --app=superset.tasks.celery_app:app worker --pool=prefork -O fair -c 4
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/src/roles/apache_superset/templates/superset.service.j2
+++ b/src/roles/apache_superset/templates/superset.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Apache Superset
+After=network.target
+
+[Service]
+Type=simple
+User={{ superset_user }}
+Group={{ superset_group }}
+WorkingDirectory={{ superset_install_dir }}
+Environment=SUPERSET_CONFIG_PATH={{ superset_config_path }}
+ExecStart={{ superset_venv_dir }}/bin/gunicorn -w {{ superset_gunicorn_workers }} -k gevent --timeout 120 -b {{ superset_gunicorn_bind }} --limit-request-line 0 --limit-request-field_size 0 superset.app:create_app()
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/src/roles/apache_superset/templates/superset_config.py.j2
+++ b/src/roles/apache_superset/templates/superset_config.py.j2
@@ -1,0 +1,20 @@
+import os
+
+SECRET_KEY = "{{ superset_secret_key }}"
+
+SQLALCHEMY_DATABASE_URI = "{{ superset_database_uri }}"
+
+{% if superset_redis_url %}
+CACHE_TYPE = "RedisCache"
+CACHE_REDIS_URL = "{{ superset_redis_url }}"
+{% endif %}
+
+{% if superset_celery_broker_url %}
+CELERY_BROKER_URL = "{{ superset_celery_broker_url }}"
+RESULT_BACKEND = "{{ superset_celery_broker_url }}"
+{% endif %}
+
+{% for key, value in superset_feature_flags.items() %}
+FEATURE_FLAGS = FEATURE_FLAGS if 'FEATURE_FLAGS' in globals() else {}
+FEATURE_FLAGS["{{ key }}"] = {{ value }}
+{% endfor %}


### PR DESCRIPTION
## Summary
- add a new `apache_superset` role with tasks for install, config, database init, and service management
- include templates for Superset configuration and service units
- provide default variable definitions and a README

## Testing
- `git status --short`