### PR TITLE
Add Keycloak role with playbooks and inventory

### DIFF
--- a/src/ansible.cfg
+++ b/src/ansible.cfg
@@ -1,9 +1,14 @@
 [defaults]
-roles_path = roles
-collections_paths = collections
+inventory           = inventories
+roles_path          = roles
+forks               = 20
 retry_files_enabled = false
-stdout_callback = yaml
-inventory = inventories/production
+stdout_callback     = yaml
+host_key_checking   = false
+interpreter_python  = auto
+fact_caching        = jsonfile
+fact_caching_connection = .ansible_facts
+collections_paths = collections
 
 [privilege_escalation]
 become = false

--- a/src/inventories/dev/hosts.yml
+++ b/src/inventories/dev/hosts.yml
@@ -1,0 +1,6 @@
+all:
+  children:
+    keycloak:
+      hosts:
+        keycloak-dev-1:
+          ansible_host: 10.0.1.10

--- a/src/inventories/prod/group_vars/keycloak.yml
+++ b/src/inventories/prod/group_vars/keycloak.yml
@@ -1,0 +1,25 @@
+keycloak_version: "24.0.4"
+keycloak_install_dir: /opt
+keycloak_user: keycloak
+keycloak_group: keycloak
+keycloak_db_host: db.prod.example.com
+keycloak_db_port: 5432
+keycloak_db_name: keycloak
+keycloak_db_user: keycloak
+keycloak_db_password: "{{ vault_keycloak_db_password }}"
+keycloak_bind: "0.0.0.0"
+keycloak_http_port: 8080
+keycloak_https_port: 8443
+keycloak_cluster: true
+keycloak_cache_stack: "cluster"
+keycloak_admin_user: admin
+keycloak_admin_password: "{{ vault_keycloak_admin_password }}"
+keycloak_realms:
+  - name: sample-realm
+    displayName: Sample Realm
+    enabled: true
+    clients:
+      - clientId: sample-client
+        publicClient: true
+        redirectUris:
+          - "https://app.example.com/*"

--- a/src/inventories/prod/group_vars/vault.yml
+++ b/src/inventories/prod/group_vars/vault.yml
@@ -1,0 +1,2 @@
+vault_keycloak_db_password: "change_me"
+vault_keycloak_admin_password: "change_me"

--- a/src/inventories/prod/hosts.yml
+++ b/src/inventories/prod/hosts.yml
@@ -10,3 +10,14 @@ all:
         node1.example.com:
         node2.example.com:
         node3.example.com:
+    keycloak_site_a:
+      hosts:
+        kc-sitea-01:
+        kc-sitea-02:
+    keycloak_site_b:
+      hosts:
+        kc-siteb-01:
+        kc-siteb-02:
+  vars:
+    ansible_user: debian
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no"

--- a/src/playbooks/keycloak_dev.yml
+++ b/src/playbooks/keycloak_dev.yml
@@ -1,0 +1,14 @@
+- name: Deploy Keycloak (dev)
+  hosts: keycloak
+  become: true
+  vars:
+    keycloak_cluster: false
+    keycloak_db_host: localhost           # use local postgres or H2
+    keycloak_db_port: 5432
+    keycloak_db_name: keycloak
+    keycloak_db_user: keycloak
+    keycloak_db_password: keycloak
+  roles:
+    - role: postgresql_client
+    - role: keycloak
+    - role: keycloak_realm

--- a/src/playbooks/keycloak_prod.yml
+++ b/src/playbooks/keycloak_prod.yml
@@ -1,0 +1,8 @@
+- name: Deploy Keycloak (prod – rolling)
+  hosts: keycloak
+  become: true
+  serial: 1
+  roles:
+    - role: postgresql_client
+    - role: keycloak
+    - role: keycloak_realm

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -12,3 +12,5 @@ collections:
     version: "8.6.0"
   - name: community.cloudflare
     version: ">=2.0.0"
+  - name: community.postgresql
+    version: ">=2.5.0"

--- a/src/roles/keycloak/defaults/main.yml
+++ b/src/roles/keycloak/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+keycloak_version: "24.0.4"
+keycloak_install_dir: /opt
+keycloak_user: keycloak
+keycloak_group: keycloak
+keycloak_http_port: 8080
+keycloak_https_port: 8443
+keycloak_bind: "0.0.0.0"
+keycloak_db_host: localhost
+keycloak_db_port: 5432
+keycloak_db_name: keycloak
+keycloak_db_user: keycloak
+keycloak_db_password: password
+keycloak_cluster: false
+keycloak_cache_stack: "cluster"
+keycloak_admin_user: admin
+keycloak_admin_password: admin
+keycloak_realms: []

--- a/src/roles/keycloak/handlers/main.yml
+++ b/src/roles/keycloak/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: daemon reload
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: restart keycloak
+  ansible.builtin.systemd:
+    name: keycloak
+    state: restarted
+    enabled: true

--- a/src/roles/keycloak/meta/main.yml
+++ b/src/roles/keycloak/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: common

--- a/src/roles/keycloak/tasks/config.yml
+++ b/src/roles/keycloak/tasks/config.yml
@@ -1,0 +1,33 @@
+---
+- name: Deploy env file
+  ansible.builtin.template:
+    src: keycloak.env.j2
+    dest: "{{ keycloak_install_dir }}/keycloak/.env"
+    owner: "{{ keycloak_user }}"
+    group: "{{ keycloak_group }}"
+    mode: '0640'
+  notify: restart keycloak
+
+- name: Deploy systemd service
+  ansible.builtin.template:
+    src: keycloak.service.j2
+    dest: /etc/systemd/system/keycloak.service
+    mode: '0644'
+  notify:
+    - daemon reload
+    - restart keycloak
+
+- name: Open firewall (ufw) ports
+  ansible.builtin.ufw:
+    rule: allow
+    port: "{{ item }}"
+  loop:
+    - "{{ keycloak_http_port }}"
+    - "{{ keycloak_https_port }}"
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Start and enable service
+  ansible.builtin.systemd:
+    name: keycloak
+    state: started
+    enabled: yes

--- a/src/roles/keycloak/tasks/install.yml
+++ b/src/roles/keycloak/tasks/install.yml
@@ -1,0 +1,50 @@
+---
+- name: Ensure group exists
+  ansible.builtin.group:
+    name: "{{ keycloak_group }}"
+    state: present
+
+- name: Ensure user exists
+  ansible.builtin.user:
+    name: "{{ keycloak_user }}"
+    group: "{{ keycloak_group }}"
+    shell: /bin/false
+    create_home: false
+    state: present
+
+- name: Install dependencies
+  ansible.builtin.apt:
+    name:
+      - openjdk-17-jre-headless
+      - unzip
+    state: present
+    update_cache: true
+
+- name: Download Keycloak archive
+  ansible.builtin.get_url:
+    url: "https://github.com/keycloak/keycloak/releases/download/{{ keycloak_version }}/keycloak-{{ keycloak_version }}.tar.gz"
+    dest: "/tmp/keycloak-{{ keycloak_version }}.tar.gz"
+    checksum: "sha256:{{ keycloak_checksum | default('') }}"
+    mode: '0644'
+
+- name: Extract archive
+  ansible.builtin.unarchive:
+    src: "/tmp/keycloak-{{ keycloak_version }}.tar.gz"
+    dest: "{{ keycloak_install_dir }}"
+    remote_src: yes
+    creates: "{{ keycloak_install_dir }}/keycloak-{{ keycloak_version }}"
+
+- name: Create symlink to current version
+  ansible.builtin.file:
+    src: "{{ keycloak_install_dir }}/keycloak-{{ keycloak_version }}"
+    dest: "{{ keycloak_install_dir }}/keycloak"
+    state: link
+    force: true
+
+- name: Ensure ownership
+  ansible.builtin.file:
+    path: "{{ keycloak_install_dir }}/keycloak-{{ keycloak_version }}"
+    state: directory
+    recurse: yes
+    owner: "{{ keycloak_user }}"
+    group: "{{ keycloak_group }}"

--- a/src/roles/keycloak/tasks/main.yml
+++ b/src/roles/keycloak/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Include install tasks
+  import_tasks: install.yml
+
+- name: Include configuration tasks
+  import_tasks: config.yml

--- a/src/roles/keycloak/templates/keycloak.env.j2
+++ b/src/roles/keycloak/templates/keycloak.env.j2
@@ -1,0 +1,17 @@
+KC_DB=postgres
+KC_DB_URL_HOST={{ keycloak_db_host }}
+KC_DB_URL_PORT={{ keycloak_db_port }}
+KC_DB_URL_DATABASE={{ keycloak_db_name }}
+KC_DB_USERNAME={{ keycloak_db_user }}
+KC_DB_PASSWORD={{ keycloak_db_password }}
+KC_HOSTNAME_STRICT=false
+KC_PROXY=edge
+{% if keycloak_cluster %}
+KC_CACHE_STACK={{ keycloak_cache_stack }}
+{% endif %}
+KC_HTTP_ENABLED=true
+KC_HTTP_PORT={{ keycloak_http_port }}
+KC_HTTPS_PORT={{ keycloak_https_port }}
+KC_HOSTNAME_BIND_ADDRESS={{ keycloak_bind }}
+KEYCLOAK_ADMIN={{ keycloak_admin_user }}
+KEYCLOAK_ADMIN_PASSWORD={{ keycloak_admin_password }}

--- a/src/roles/keycloak/templates/keycloak.service.j2
+++ b/src/roles/keycloak/templates/keycloak.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Keycloak Service
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile={{ keycloak_install_dir }}/keycloak/.env
+User={{ keycloak_user }}
+Group={{ keycloak_group }}
+ExecStart={{ keycloak_install_dir }}/keycloak/bin/kc.sh start --optimized
+Restart=on-failure
+RestartSec=10s
+LimitNOFILE=65535
+
+[Install]
+WantedBy=multi-user.target

--- a/src/roles/keycloak_realm/tasks/main.yml
+++ b/src/roles/keycloak_realm/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: "Ensure realms are present"
+  community.general.keycloak_realm:
+    auth_keycloak_url: "http://{{ inventory_hostname }}:{{ keycloak_http_port }}"
+    auth_username: "{{ keycloak_admin_user }}"
+    auth_password: "{{ keycloak_admin_password }}"
+    realm: "{{ item.name }}"
+    state: present
+    enabled: "{{ item.enabled | default(true) }}"
+    display_name: "{{ item.displayName | default(item.name) }}"
+  loop: "{{ keycloak_realms }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: "Ensure clients for each realm"
+  community.general.keycloak_client:
+    auth_keycloak_url: "http://{{ inventory_hostname }}:{{ keycloak_http_port }}"
+    auth_username: "{{ keycloak_admin_user }}"
+    auth_password: "{{ keycloak_admin_password }}"
+    realm: "{{ realm.name }}"
+    client_id: "{{ client.clientId }}"
+    public_client: "{{ client.publicClient | default(true) }}"
+    redirect_uris: "{{ client.redirectUris | default([]) }}"
+    state: present
+  loop: "{{ keycloak_realms | subelements('clients') }}"
+  loop_control:
+    label: "{{ realm.name }} / {{ client.clientId }}"
+  vars:
+    realm: "{{ item.0 }}"
+    client: "{{ item.1 }}"

--- a/src/roles/postgresql_client/tasks/main.yml
+++ b/src/roles/postgresql_client/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Install PostgreSQL client packages
+  ansible.builtin.apt:
+    name:
+      - postgresql-client
+    state: present
+    update_cache: true
+
+- name: Ensure Keycloak database
+  community.postgresql.postgresql_db:
+    name: "{{ keycloak_db_name }}"
+    login_host: "{{ keycloak_db_host }}"
+    login_user: "{{ keycloak_db_user }}"
+    login_password: "{{ keycloak_db_password }}"
+    state: present
+
+- name: Ensure Keycloak DB user
+  community.postgresql.postgresql_user:
+    name: "{{ keycloak_db_user }}"
+    password: "{{ keycloak_db_password }}"
+    login_host: "{{ keycloak_db_host }}"
+    role_attr_flags: LOGIN
+    state: present


### PR DESCRIPTION
## Summary
- configure ansible defaults
- add dev/prod inventory definitions for Keycloak
- add Keycloak variables and vault placeholders
- create playbooks for dev and prod deployments
- implement `keycloak`, `postgresql_client`, and `keycloak_realm` roles
- include `community.postgresql` collection in requirements

## Testing
- `pytest --version` *(fails: command not found)*