### PR TITLE
Add Keycloak role with CI and docs

### DIFF
--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -1,0 +1,21 @@
+name: Ansible CI
+
+on: [push, pull_request]
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with: {python-version: '3.11'}
+      - name: Install deps
+        run: |
+          pip install ansible-core ansible-lint molecule[docker] yamllint
+          ansible-galaxy collection install -r requirements.yml
+      - name: Lint
+        run: ansible-lint .
+      - name: Molecule
+        working-directory: roles/keycloak
+        run: molecule test

--- a/docs/keycloak-role.md
+++ b/docs/keycloak-role.md
@@ -1,0 +1,19 @@
+# Keycloak Role
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `keycloak_version` | `24.0.1` | Keycloak release to install |
+| `keycloak_db_host` | _(required)_ | PostgreSQL host |
+| `keycloak_db_name` | `keycloak` | Database name |
+| `keycloak_db_user` | `keycloak` | DB username |
+| `keycloak_db_password` | _(vaulted)_ | DB password |
+
+## Example
+
+```yaml
+- hosts: keycloak
+  roles:
+    - role: keycloak
+      vars:
+        keycloak_version: "24.0.1"
+```

--- a/group_vars/keycloak.yml
+++ b/group_vars/keycloak.yml
@@ -1,0 +1,7 @@
+---
+keycloak_db_host: "postgres.example.com"
+keycloak_db_name: "keycloak"
+keycloak_db_user: "keycloak"
+keycloak_db_password: "!vault |
+          $ANSIBLE_VAULT;1.1;AES256;example
+          <encrypted text here>"

--- a/molecule/keycloak/default/molecule.yml
+++ b/molecule/keycloak/default/molecule.yml
@@ -1,0 +1,16 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: keycloak
+    image: geerlingguy/docker-debian12-ansible:latest
+    command: "/lib/systemd/systemd"
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ../../../../playbooks/keycloak.yml
+verifier:
+  name: testinfra

--- a/playbooks/keycloak.yml
+++ b/playbooks/keycloak.yml
@@ -1,0 +1,6 @@
+---
+- name: Deploy Keycloak
+  hosts: keycloak
+  become: true
+  roles:
+    - keycloak

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,0 +1,2 @@
+---
+- import_playbook: keycloak.yml

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,6 @@
 ---
 collections:
+  - name: community.postgresql
+    version: ">=3.4.0"
   - name: community.general
-    version: ">=8.2.0"
+    version: ">=8.4.0"

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+keycloak_version: "24.0.1"
+keycloak_user: "keycloak"
+keycloak_home: "/var/lib/keycloak"
+keycloak_install_dir: "{{ keycloak_home }}/keycloak-{{ keycloak_version }}"
+keycloak_download_url: "https://github.com/keycloak/keycloak/releases/download/{{ keycloak_version }}/keycloak-{{ keycloak_version }}.tar.gz"
+keycloak_http_port: 8080
+keycloak_packages:
+  - unzip
+  - curl
+  - openjdk-17-jre-headless

--- a/roles/keycloak/handlers/main.yml
+++ b/roles/keycloak/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Reload systemd
+  systemd:
+    daemon_reload: yes
+
+- name: Restart Keycloak
+  systemd:
+    name: keycloak
+    state: restarted

--- a/roles/keycloak/meta/main.yml
+++ b/roles/keycloak/meta/main.yml
@@ -1,0 +1,6 @@
+---
+dependencies:
+  - role: java
+collections:
+  - community.postgresql
+  - community.general

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+- name: Ensure required apt packages are present
+  apt:
+    name: "{{ keycloak_packages }}"
+    state: present
+    update_cache: yes
+
+- name: Create keycloak system user
+  user:
+    name: "{{ keycloak_user }}"
+    system: yes
+    home: "{{ keycloak_home }}"
+    shell: /usr/sbin/nologin
+
+- name: Download Keycloak archive
+  get_url:
+    url: "{{ keycloak_download_url }}"
+    dest: "/tmp/keycloak-{{ keycloak_version }}.tar.gz"
+    mode: '0644'
+  args:
+    creates: "/tmp/keycloak-{{ keycloak_version }}.tar.gz"
+
+- name: Unpack Keycloak to install dir
+  unarchive:
+    src: "/tmp/keycloak-{{ keycloak_version }}.tar.gz"
+    dest: "{{ keycloak_install_dir }}"
+    owner: "{{ keycloak_user }}"
+    group: "{{ keycloak_user }}"
+    remote_src: yes
+    creates: "{{ keycloak_install_dir }}/bin/kc.sh"
+
+- name: Deploy systemd unit file
+  template:
+    src: keycloak.service.j2
+    dest: /etc/systemd/system/keycloak.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Reload systemd
+
+- name: Deploy Keycloak configuration
+  template:
+    src: keycloak.conf.j2
+    dest: "{{ keycloak_install_dir }}/conf/keycloak.conf"
+    owner: "{{ keycloak_user }}"
+    group: "{{ keycloak_user }}"
+    mode: '0640'
+  notify: Restart Keycloak
+
+- name: Ensure Keycloak is enabled and started
+  systemd:
+    name: keycloak
+    enabled: yes
+    state: started

--- a/roles/keycloak/templates/keycloak.conf.j2
+++ b/roles/keycloak/templates/keycloak.conf.j2
@@ -1,0 +1,7 @@
+KC_DB=postgres
+KC_DB_URL=jdbc:postgresql://{{ keycloak_db_host }}:5432/{{ keycloak_db_name }}
+KC_DB_USERNAME={{ keycloak_db_user }}
+KC_DB_PASSWORD={{ keycloak_db_password }}
+KC_HOSTNAME={{ keycloak_hostname | default(inventory_hostname) }}
+KC_HTTP_PORT={{ keycloak_http_port }}
+KC_PROXY=edge

--- a/roles/keycloak/templates/keycloak.service.j2
+++ b/roles/keycloak/templates/keycloak.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Keycloak Identity & Access Management
+After=network.target
+
+[Service]
+Type=simple
+User={{ keycloak_user }}
+Group={{ keycloak_user }}
+EnvironmentFile={{ keycloak_install_dir }}/conf/keycloak.conf
+ExecStart={{ keycloak_install_dir }}/bin/kc.sh start --optimized
+Restart=on-failure
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/src/inventories/prod/hosts.ini
+++ b/src/inventories/prod/hosts.ini
@@ -5,3 +5,7 @@ ca3.prod.example.com ansible_host=10.0.2.12
 
 [mysql_servers]
 ca-db.prod.example.com ansible_host=10.0.0.20
+
+[keycloak]
+kc-node1.example.com
+kc-node2.example.com


### PR DESCRIPTION
## Summary
- add Keycloak role with tasks, handlers, defaults, templates
- configure inventories and playbooks
- document the role
- add Molecule scenario and GitHub Actions CI
- update collection requirements

## Testing
- `ansible-lint` *(fails: command not found)*