### PR TITLE
Fix ansible lint issues

### DIFF
--- a/src/roles/keycloak/handlers/main.yml
+++ b/src/roles/keycloak/handlers/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Reload systemd
-  systemd:
-    daemon_reload: yes
+  ansible.builtin.systemd:
+    daemon_reload: true
 
 - name: Restart Keycloak
-  systemd:
+  ansible.builtin.systemd:
     name: keycloak
     state: restarted

--- a/src/roles/keycloak/tasks/main.yml
+++ b/src/roles/keycloak/tasks/main.yml
@@ -1,36 +1,35 @@
 ---
 - name: Ensure required apt packages are present
-  apt:
+  ansible.builtin.apt:
     name: "{{ keycloak_packages }}"
     state: present
-    update_cache: yes
+    update_cache: true
 
 - name: Create keycloak system user
-  user:
+  ansible.builtin.user:
     name: "{{ keycloak_user }}"
-    system: yes
+    system: true
     home: "{{ keycloak_home }}"
     shell: /usr/sbin/nologin
 
 - name: Download Keycloak archive
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ keycloak_download_url }}"
     dest: "/tmp/keycloak-{{ keycloak_version }}.tar.gz"
     mode: '0644'
-  args:
-    creates: "/tmp/keycloak-{{ keycloak_version }}.tar.gz"
+    force: false
 
 - name: Unpack Keycloak to install dir
-  unarchive:
+  ansible.builtin.unarchive:
     src: "/tmp/keycloak-{{ keycloak_version }}.tar.gz"
     dest: "{{ keycloak_install_dir }}"
     owner: "{{ keycloak_user }}"
     group: "{{ keycloak_user }}"
-    remote_src: yes
+    remote_src: true
     creates: "{{ keycloak_install_dir }}/bin/kc.sh"
 
 - name: Deploy systemd unit file
-  template:
+  ansible.builtin.template:
     src: keycloak.service.j2
     dest: /etc/systemd/system/keycloak.service
     owner: root
@@ -39,7 +38,7 @@
   notify: Reload systemd
 
 - name: Deploy Keycloak configuration
-  template:
+  ansible.builtin.template:
     src: keycloak.conf.j2
     dest: "{{ keycloak_install_dir }}/conf/keycloak.conf"
     owner: "{{ keycloak_user }}"
@@ -48,7 +47,7 @@
   notify: Restart Keycloak
 
 - name: Ensure Keycloak is enabled and started
-  systemd:
+  ansible.builtin.systemd:
     name: keycloak
-    enabled: yes
+    enabled: true
     state: started


### PR DESCRIPTION
## Summary
- fix ansible lint issues in keycloak role handlers
- fix ansible lint issues in keycloak role tasks

## Testing
- `ansible-lint --version`
- `ansible-lint --offline src/roles/keycloak` *(fails: the role 'java' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cbad1e458832a94e08034f972f3eb