### PR TITLE
Fix some ansible lint issues

### DIFF
--- a/src/roles/openldap_replication/tasks/main.yml
+++ b/src/roles/openldap_replication/tasks/main.yml
@@ -5,7 +5,7 @@
   when: not ldap_replication
 
 - name: Set olcServerID
-  community.general.ldap_attr:
+  community.general.ldap_attrs:
     dn: "cn=config"
     attribute: olcServerID
     values: "{{ ansible_play_hosts_all.index(inventory_hostname) + 1 }} {{ inventory_hostname }}"

--- a/src/roles/openldap_server/tasks/config.yml
+++ b/src/roles/openldap_server/tasks/config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set log level
-  community.general.ldap_attr:
+  community.general.ldap_attrs:
     dn: "cn=config"
     attribute: olcLogLevel
     values: "{{ ldap_log_level }}"

--- a/src/roles/openldap_server/tasks/tls.yml
+++ b/src/roles/openldap_server/tasks/tls.yml
@@ -24,7 +24,7 @@
     mode: "0644"
 
 - name: Configure slapd TLS settings
-  community.general.ldap_attr:
+  community.general.ldap_attrs:
     dn: "cn=config"
     attributes:
       olcTLSCertificateFile: "/etc/ldap/ssl/ldap.crt"

--- a/src/roles/update_system/tasks/main.yml
+++ b/src/roles/update_system/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Retry apt update and upgrade
   block:
     - name: Update and upgrade system
-      apt:
+      ansible.builtin.apt:
         upgrade: yes
         update_cache: yes
       register: apt_result
@@ -11,5 +11,5 @@
       delay: 10
   rescue:
     - name: Handle failure
-      debug:
+      ansible.builtin.debug:
         msg: "Failed to update and upgrade system"


### PR DESCRIPTION
## Summary
- address deprecated `community.general.ldap_attr` usage
- use FQCNs for apt and debug

## Testing
- `ansible-lint` *(fails: 985 failure(s))*

------
https://chatgpt.com/codex/tasks/task_e_683cc7f9ddd0832a81f333e72b0837e2