### PR TITLE
Fix some ansible-lint warnings

### DIFF
--- a/src/roles/apt_mirror_client_setup/README.md
+++ b/src/roles/apt_mirror_client_setup/README.md
@@ -39,11 +39,11 @@ Below is a list of the variable that can be configured for this role, along with
 
 | Variable             | Default Value                | Description                                                                                                                                                                                                                                                                                                                                                                                                            |
 | -------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`apt_mirror_url`** | `http://your-apt-mirror-url` | Base URL of the APT mirror server that clients should use for package downloads. This should include the protocol (`http://` or `https://`) and any path prefix required to reach the mirror’s repository root. For example: `http://mirror.example.com/mirror` (if using the default Apache alias from the **apt_mirror** role). All entries in the generated `/etc/apt/sources.list` will use this URL as the base. |
+| **`apt_mirror_client_setup_url`** | `http://your-apt-mirror-url` | Base URL of the APT mirror server that clients should use for package downloads. This should include the protocol (`http://` or `https://`) and any path prefix required to reach the mirror’s repository root. For example: `http://mirror.example.com/mirror` (if using the default Apache alias from the **apt_mirror** role). All entries in the generated `/etc/apt/sources.list` will use this URL as the base. |
 
 </details>
 
-Typically, you will override `apt_mirror_url` in your inventory or playbook to point to your own mirror. **No other variables are needed** for this role; it automatically detects the client’s OS and release to construct the appropriate APT sources list.
+Typically, you will override `apt_mirror_client_setup_url` in your inventory or playbook to point to your own mirror. **No other variables are needed** for this role; it automatically detects the client’s OS and release to construct the appropriate APT sources list.
 
 ## Tags
 
@@ -63,12 +63,12 @@ Below is an example of how to use the `apt_mirror_client_setup` role in a playbo
 - hosts: clients
   become: yes
   vars:
-    apt_mirror_url: "http://apt-mirror.internal/mirror"
+    apt_mirror_client_setup_url: "http://apt-mirror.internal/mirror"
   roles:
     - apt_mirror_client_setup
 ```
 
-In the above playbook, the role will template the file `/etc/apt/sources.list` on all hosts in the **`clients`** group to use the specified `apt_mirror_url`, then run an apt update to refresh the package cache. Ensure that **`become: yes`** is set, as modifying system package sources and updating caches requires root privileges.
+In the above playbook, the role will template the file `/etc/apt/sources.list` on all hosts in the **`clients`** group to use the specified `apt_mirror_client_setup_url`, then run an apt update to refresh the package cache. Ensure that **`become: yes`** is set, as modifying system package sources and updating caches requires root privileges.
 
 If your mirror server was set up using the **apt_mirror** role, the URL typically includes the `/mirror` path as shown (unless you configured a custom alias). After running this play, you can immediately test package operations on the client (e.g. `apt-get upgrade` or `apt install <package>`) to confirm they are pulling from your mirror.
 
@@ -83,12 +83,12 @@ It is recommended to test this role using **Molecule** (with the Docker driver) 
    molecule init scenario -r apt_mirror_client_setup -d docker
    ```
 
-   This will set up a default Molecule configuration using Docker containers. You may need to edit the generated `molecule/default/converge.yml` to include any required variables. For example, set `apt_mirror_url` to a reachable mirror for the test (see next step).
+   This will set up a default Molecule configuration using Docker containers. You may need to edit the generated `molecule/default/converge.yml` to include any required variables. For example, set `apt_mirror_client_setup_url` to a reachable mirror for the test (see next step).
 3. **Configure a test mirror source:** For testing in isolation, you have a couple of options:
 
-   * **Use a public mirror:** You can point `apt_mirror_url` to an official mirror (like `http://archive.ubuntu.com/ubuntu`) or a country mirror. This essentially replicates the default sources, but it ensures the role still makes changes and that the apt update will succeed online.
-   * **Use a local test mirror:** If you have the **apt_mirror** role’s mirror server running in a container or VM accessible to the test container, use its URL. For example, you might run a mirror container and then set `apt_mirror_url` to that container’s IP (and port/path if different).
-     Update the Molecule scenario’s playbook to include the chosen `apt_mirror_url` so that the container will use a valid source.
+   * **Use a public mirror:** You can point `apt_mirror_client_setup_url` to an official mirror (like `http://archive.ubuntu.com/ubuntu`) or a country mirror. This essentially replicates the default sources, but it ensures the role still makes changes and that the apt update will succeed online.
+   * **Use a local test mirror:** If you have the **apt_mirror** role’s mirror server running in a container or VM accessible to the test container, use its URL. For example, you might run a mirror container and then set `apt_mirror_client_setup_url` to that container’s IP (and port/path if different).
+     Update the Molecule scenario’s playbook to include the chosen `apt_mirror_client_setup_url` so that the container will use a valid source.
 4. **Run the role in a container:** Execute Molecule to apply the role:
 
    ```bash
@@ -96,18 +96,18 @@ It is recommended to test this role using **Molecule** (with the Docker driver) 
    ```
 
    Molecule will launch a fresh Docker container (by default using a Debian or Ubuntu base image) and run the `apt_mirror_client_setup` role inside it. The tasks will template the sources list and update the cache.
-5. **Verify the results:** After the converge, check that the container’s APT configuration is updated. You can do this by opening a shell in the container (`molecule login -s default`) and inspecting `/etc/apt/sources.list` – it should contain your `apt_mirror_url` in all entries. Also, you can run `apt-get update` (if it wasn’t run) or `apt-cache policy` to ensure no errors and that the repository is recognized. If you have automated tests (e.g., with Testinfra or Inspec), you can run `molecule verify` to execute them. For example, a Testinfra test might assert that the content of `/etc/apt/sources.list` matches the expected mirror URLs.
+5. **Verify the results:** After the converge, check that the container’s APT configuration is updated. You can do this by opening a shell in the container (`molecule login -s default`) and inspecting `/etc/apt/sources.list` – it should contain your `apt_mirror_client_setup_url` in all entries. Also, you can run `apt-get update` (if it wasn’t run) or `apt-cache policy` to ensure no errors and that the repository is recognized. If you have automated tests (e.g., with Testinfra or Inspec), you can run `molecule verify` to execute them. For example, a Testinfra test might assert that the content of `/etc/apt/sources.list` matches the expected mirror URLs.
 6. **Cleanup:** Once testing is done, tear down the test container with `molecule destroy -s default`. You can also run the full test cycle (create, converge, verify, destroy) in one go with `molecule test`.
 
-Using Molecule for testing helps ensure the role performs as expected (e.g., idempotently updating the sources file and not producing errors) on a fresh system. During testing, it’s a good idea to run the role at least twice on the same container to confirm idempotence – the second run should report zero changes (if `apt_mirror_url` remains the same and the mirror is reachable).
+Using Molecule for testing helps ensure the role performs as expected (e.g., idempotently updating the sources file and not producing errors) on a fresh system. During testing, it’s a good idea to run the role at least twice on the same container to confirm idempotence – the second run should report zero changes (if `apt_mirror_client_setup_url` remains the same and the mirror is reachable).
 
 ## Known Issues and Gotchas
 
-* **Mirror Reachability:** The client must be able to reach the specified `apt_mirror_url` over the network. If the URL is wrong, the mirror server is down, or networking is blocked, the APT update will fail. Double-check DNS names or IP addresses and ensure any firewalls allow access to the mirror. A quick way to test reachability is to `curl` or `ping` the mirror URL from the client hosts before applying this role.
+* **Mirror Reachability:** The client must be able to reach the specified `apt_mirror_client_setup_url` over the network. If the URL is wrong, the mirror server is down, or networking is blocked, the APT update will fail. Double-check DNS names or IP addresses and ensure any firewalls allow access to the mirror. A quick way to test reachability is to `curl` or `ping` the mirror URL from the client hosts before applying this role.
 * **Repository Availability Match:** Ensure the mirror contains all the repository components that the client expects. The template used by this role will typically include main release, updates, and security repositories for the client’s distribution. If your mirror was configured (via the **apt_mirror** role or otherwise) to skip certain components (for example, you mirrored only “main” and “universe” but not “multiverse”, or you omitted security updates), you should adjust the client configuration accordingly. Missing repositories on the mirror will cause `apt-get update` to complain about “Failed to fetch” errors. In such cases, either include those components in your mirror or remove/alter those entries in the client’s sources list template.
 * **Overwriting Default Sources:** This role **replaces** the default `/etc/apt/sources.list` file. Any custom repository entries that were manually added to that file will be lost when the template is applied. However, the role does **not** touch files under `/etc/apt/sources.list.d/`. So if you have additional APT sources defined in separate files (e.g., for third-party PPAs or other software), those will remain active. Keep in mind that those external sources will continue to fetch from their original locations unless you also mirror them or update those files separately.
-* **Mirror Outage or Lag:** When all clients rely on a single mirror, a downtime or out-of-date mirror can impact your environment. If the mirror server goes offline or hasn’t synced recently, clients might be unable to install packages or may install older versions. It’s wise to have a contingency plan: for example, maintain a secondary mirror for failover, or a procedure to quickly switch clients back to official repositories (perhaps by reverting this role’s changes or pointing `apt_mirror_url` to a public mirror temporarily) during emergencies.
-* **HTTP vs HTTPS Mirrors:** By default, apt-mirror and this role assume an HTTP mirror (the apt-mirror utility typically syncs from and serves via HTTP). Using HTTP internally is usually fine (APT still verifies package signatures), but be aware that traffic is unencrypted. If your environment mandates encryption, consider setting up HTTPS on your mirror server and use an appropriate `apt_mirror_url` (e.g. `https://mirror.example.com/...`) along with deploying the mirror’s SSL certificate to clients (or using a trusted CA). Also note that if you use a self-signed certificate or an internal CA, clients will need the CA certificate installed to avoid TLS errors. This goes beyond the default scope of this role (which doesn’t handle certificate trust), but is important for security in sensitive environments.
+* **Mirror Outage or Lag:** When all clients rely on a single mirror, a downtime or out-of-date mirror can impact your environment. If the mirror server goes offline or hasn’t synced recently, clients might be unable to install packages or may install older versions. It’s wise to have a contingency plan: for example, maintain a secondary mirror for failover, or a procedure to quickly switch clients back to official repositories (perhaps by reverting this role’s changes or pointing `apt_mirror_client_setup_url` to a public mirror temporarily) during emergencies.
+* **HTTP vs HTTPS Mirrors:** By default, apt-mirror and this role assume an HTTP mirror (the apt-mirror utility typically syncs from and serves via HTTP). Using HTTP internally is usually fine (APT still verifies package signatures), but be aware that traffic is unencrypted. If your environment mandates encryption, consider setting up HTTPS on your mirror server and use an appropriate `apt_mirror_client_setup_url` (e.g. `https://mirror.example.com/...`) along with deploying the mirror’s SSL certificate to clients (or using a trusted CA). Also note that if you use a self-signed certificate or an internal CA, clients will need the CA certificate installed to avoid TLS errors. This goes beyond the default scope of this role (which doesn’t handle certificate trust), but is important for security in sensitive environments.
 
 ## Security Implications
 

--- a/src/roles/apt_mirror_client_setup/defaults/main.yml
+++ b/src/roles/apt_mirror_client_setup/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for apt_mirror_client_setup
-apt_mirror_url: "http://your-apt-mirror-url"
+apt_mirror_client_setup_url: "http://your-apt-mirror-url"

--- a/src/roles/apt_mirror_client_setup/tasks/main.yml
+++ b/src/roles/apt_mirror_client_setup/tasks/main.yml
@@ -10,4 +10,4 @@
 
 - name: Update packages list
   ansible.builtin.apt:
-    update_cache: yes
+    update_cache: true

--- a/src/roles/apt_mirror_client_setup/tempaltes/sources.list.j2
+++ b/src/roles/apt_mirror_client_setup/tempaltes/sources.list.j2
@@ -1,15 +1,15 @@
 # Debian packages
-deb {{ apt_mirror_url }}/debian stable main contrib non-free
-deb-src {{ apt_mirror_url }}/debian stable main contrib non-free
+deb {{ apt_mirror_client_setup_url }}/debian stable main contrib non-free
+deb-src {{ apt_mirror_client_setup_url }}/debian stable main contrib non-free
 
 # Debian Security
-deb {{ apt_mirror_url }}/debian-security stable-security main contrib non-free
-deb-src {{ apt_mirror_url }}/debian-security stable-security main contrib non-free
+deb {{ apt_mirror_client_setup_url }}/debian-security stable-security main contrib non-free
+deb-src {{ apt_mirror_client_setup_url }}/debian-security stable-security main contrib non-free
 
 # Debian Updates
-deb {{ apt_mirror_url }}/debian stable-updates main contrib non-free
-deb-src {{ apt_mirror_url }}/debian stable-updates main contrib non-free
+deb {{ apt_mirror_client_setup_url }}/debian stable-updates main contrib non-free
+deb-src {{ apt_mirror_client_setup_url }}/debian stable-updates main contrib non-free
 
 # Debian Backports
-deb {{ apt_mirror_url }}/debian stable-backports main contrib non-free
-deb-src {{ apt_mirror_url }}/debian stable-backports main contrib non-free
+deb {{ apt_mirror_client_setup_url }}/debian stable-backports main contrib non-free
+deb-src {{ apt_mirror_client_setup_url }}/debian stable-backports main contrib non-free

--- a/src/roles/step_ca/defaults/main.yml
+++ b/src/roles/step_ca/defaults/main.yml
@@ -1,5 +1,5 @@
 step_ca_version: "latest"
-step_cli_version: "latest"
+step_ca_cli_version: "latest"
 step_ca_user: "step"
 step_ca_group: "step"
 step_ca_home: "/home/step"

--- a/src/roles/step_ca/handlers/main.yml
+++ b/src/roles/step_ca/handlers/main.yml
@@ -1,8 +1,8 @@
 - name: Reload systemd
   ansible.builtin.systemd:
-    daemon_reload: yes
+    daemon_reload: true
 
 - name: Restart step-ca
-  service:
+  ansible.builtin.service:
     name: step-ca
     state: restarted

--- a/src/roles/step_ca/meta/main.yml
+++ b/src/roles/step_ca/meta/main.yml
@@ -1,5 +1,7 @@
+---
 galaxy_info:
   author: Example Inc.
+  description: Smallstep step-ca installation and configuration
   min_ansible_version: "2.14"
   platforms:
     - name: Debian

--- a/src/roles/step_ca/tasks/bootstrap.yml
+++ b/src/roles/step_ca/tasks/bootstrap.yml
@@ -1,13 +1,14 @@
 - name: Ensure step user exists
-  user:
+  ansible.builtin.user:
     name: "{{ step_ca_user }}"
     group: "{{ step_ca_group }}"
     shell: /usr/sbin/nologin
-    create_home: yes
+    create_home: true
 
 - name: Initialize step-ca
+  become: true
   become_user: "{{ step_ca_user }}"
-  command: >
+  ansible.builtin.command: >
     step ca init
     --non-interactive
     --name "Internal CA"
@@ -17,5 +18,5 @@
     --password-file "{{ step_ca_home }}/ca-pass.txt"
   args:
     creates: "{{ step_ca_config_path }}/ca.json"
-  when: step_ca_use_vault_ra | bool == false
+  when: not step_ca_use_vault_ra | bool
   notify: Restart step-ca

--- a/src/roles/step_ca/tasks/config.yml
+++ b/src/roles/step_ca/tasks/config.yml
@@ -1,5 +1,5 @@
 - name: Create config directory
-  file:
+  ansible.builtin.file:
     path: "{{ step_ca_config_path }}"
     owner: "{{ step_ca_user }}"
     group: "{{ step_ca_group }}"
@@ -7,7 +7,7 @@
     state: directory
 
 - name: Template ca.json
-  template:
+  ansible.builtin.template:
     src: ca.json.j2
     dest: "{{ step_ca_config_path }}/ca.json"
     owner: "{{ step_ca_user }}"
@@ -16,7 +16,7 @@
   notify: Restart step-ca
 
 - name: Template step-ca systemd unit
-  template:
+  ansible.builtin.template:
     src: step-ca.service.j2
     dest: /etc/systemd/system/step-ca.service
     mode: '0644'

--- a/src/roles/step_ca/tasks/install.yml
+++ b/src/roles/step_ca/tasks/install.yml
@@ -1,17 +1,17 @@
 - name: Add Smallstep APT key
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://dl.smallstep.com/apt/keys/steps-public-key.asc
     state: present
 
 - name: Add Smallstep repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb [arch=amd64] https://dl.smallstep.com/apt {{ ansible_distribution_release }} main"
     state: present
 
 - name: Install step and step-ca packages
-  apt:
+  ansible.builtin.apt:
     name:
-      - "step={{ step_cli_version if step_cli_version != 'latest' else '' }}"
+      - "step={{ step_ca_cli_version if step_ca_cli_version != 'latest' else '' }}"
       - "step-ca={{ step_ca_version if step_ca_version != 'latest' else '' }}"
     state: present
-    update_cache: yes
+    update_cache: true

--- a/src/roles/step_ca/tasks/main.yml
+++ b/src/roles/step_ca/tasks/main.yml
@@ -1,12 +1,12 @@
 - name: Include install tasks
-  import_tasks: install.yml
+  ansible.builtin.import_tasks: install.yml
 
 - name: Include bootstrap tasks
-  import_tasks: bootstrap.yml
+  ansible.builtin.import_tasks: bootstrap.yml
   when: step_ca_bootstrap | bool
 
 - name: Include config tasks
-  import_tasks: config.yml
+  ansible.builtin.import_tasks: config.yml
 
 - name: Include service tasks
-  import_tasks: service.yml
+  ansible.builtin.import_tasks: service.yml

--- a/src/roles/step_ca/tasks/service.yml
+++ b/src/roles/step_ca/tasks/service.yml
@@ -1,5 +1,5 @@
 - name: Enable and start step-ca
-  service:
+  ansible.builtin.service:
     name: step-ca
-    enabled: yes
+    enabled: true
     state: started


### PR DESCRIPTION
## Summary
- clean up apt_mirror_client_setup role variables
- add FQCN and other lint fixes in step_ca role

## Testing
- `ansible-lint src/roles/apt_mirror_client_setup src/roles/step_ca`

------
https://chatgpt.com/codex/tasks/task_e_683cd12f4f70832aac9be77c0a2e2b2a