### PR TITLE
Fix ansible-lint warnings in several roles

### DIFF
--- a/src/roles/neo4j/defaults/main.yml
+++ b/src/roles/neo4j/defaults/main.yml
@@ -37,14 +37,13 @@ neo4j_metrics_enabled: "{{ neo4j_edition == 'enterprise' }}"
 neo4j_metrics_listen: ":2004"
 
 neo4j_elk_integration: false
-elk_host: ""
-elk_port: 5044
-elk_cloud_id: ""
-elk_username: ""
-elk_password: ""
+neo4j_elk_host: ""
+neo4j_elk_port: 5044
+neo4j_elk_cloud_id: ""
+neo4j_elk_username: ""
+neo4j_elk_password: ""
 
 neo4j_logrotate_enable: true
 neo4j_logrotate_rotation: 7
 neo4j_logrotate_frequency: weekly
 neo4j_log_level: INFO
-

--- a/src/roles/neo4j/tasks/main.yml
+++ b/src/roles/neo4j/tasks/main.yml
@@ -1,14 +1,18 @@
 ---
-- import_tasks: install.yml
-- import_tasks: configure.yml
-- import_tasks: security.yml
-- import_tasks: backup.yml
-- import_tasks: monitoring.yml
-- import_tasks: users.yml
+- name: Include install tasks
+  ansible.builtin.import_tasks: install.yml
+- name: Include configure tasks
+  ansible.builtin.import_tasks: configure.yml
+- name: Include security tasks
+  ansible.builtin.import_tasks: security.yml
+- name: Include backup tasks
+  ansible.builtin.import_tasks: backup.yml
+- name: Include monitoring tasks
+  ansible.builtin.import_tasks: monitoring.yml
+- name: Include user tasks
+  ansible.builtin.import_tasks: users.yml
 - name: Ensure Neo4j service enabled and started
   ansible.builtin.service:
     name: neo4j
     state: started
     enabled: true
-
-

--- a/src/roles/neo4j/templates/filebeat.yml.j2
+++ b/src/roles/neo4j/templates/filebeat.yml.j2
@@ -8,5 +8,5 @@ filebeat.inputs:
       cluster: "{{ 'cluster' if neo4j_cluster_enabled else 'single' }}"
 
 output.logstash:
-  hosts: ["{{ elk_host }}:{{ elk_port }}"]
+  hosts: ["{{ neo4j_elk_host }}:{{ neo4j_elk_port }}"]
 

--- a/src/roles/netbox/handlers/main.yml
+++ b/src/roles/netbox/handlers/main.yml
@@ -1,11 +1,11 @@
 ---
-- name: restart netbox
+- name: Restart NetBox
   ansible.builtin.systemd:
     name: netbox
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
 
-- name: reload nginx
+- name: Reload Nginx
   ansible.builtin.service:
     name: nginx
     state: reloaded

--- a/src/roles/sshd/defaults/main.yml
+++ b/src/roles/sshd/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-ssh_listen_address: "{{ hostvars[inventory_hostname]['ansible_host'] }}"
+sshd_listen_address: "{{ hostvars[inventory_hostname]['ansible_host'] }}"

--- a/src/roles/sshd/handlers/main.yml
+++ b/src/roles/sshd/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart ssh
-  systemd:
+- name: Restart SSH
+  ansible.builtin.systemd:
     name: sshd
     state: restarted

--- a/src/roles/sshd/tasks/main.yml
+++ b/src/roles/sshd/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Update SSHD Configuration
-  template:
+  ansible.builtin.template:
     src: sshd_config.j2
     dest: /etc/ssh/sshd_config
     owner: root
     group: root
-    mode: 0644
-  notify: restart ssh
+    mode: "0644"
+  notify: Restart SSH

--- a/src/roles/sshd/templates/sshd_config copy.j2
+++ b/src/roles/sshd/templates/sshd_config copy.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 Port 22
 AddressFamily inet
-ListenAddress {{ ssh_listen_address }}
+ListenAddress {{ sshd_listen_address }}
 Protocol 2
 Compression yes
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes256-ctr

--- a/src/roles/update_system/tasks/main.yml
+++ b/src/roles/update_system/tasks/main.yml
@@ -3,8 +3,8 @@
   block:
     - name: Update and upgrade system
       ansible.builtin.apt:
-        upgrade: yes
-        update_cache: yes
+        upgrade: true
+        update_cache: true
       register: apt_result
       until: apt_result is success
       retries: 10


### PR DESCRIPTION
## Summary
- rename ELK variables in neo4j role and update references
- add names and FQCNs to neo4j main tasks
- adjust sshd role defaults and templates
- clean up handlers and tasks for sshd and netbox
- fix truthy values in update_system role

## Testing
- `ansible-lint src/roles/sshd/tasks/main.yml src/roles/sshd/handlers/main.yml src/roles/sshd/defaults/main.yml src/roles/sshd/templates/sshd_config\ copy.j2 src/roles/netbox/handlers/main.yml src/roles/update_system/tasks/main.yml src/roles/neo4j/tasks/main.yml src/roles/neo4j/defaults/main.yml src/roles/neo4j/templates/filebeat.yml.j2` (fails: 7 failure(s), 3 warning(s))
- `ansible-lint` (fails: 908 failure(s), 28 warning(s))

------
https://chatgpt.com/codex/tasks/task_e_683cd30b9560832abd3378a1101fe943