### PR TITLE
Fix some ansible-lint warnings

### DIFF
--- a/src/roles/letsencrypt_setup/defaults/main.yml
+++ b/src/roles/letsencrypt_setup/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # defaults file for letsencrypt_setup
-domain_name: "your_domain"
-email_address: "your_email"
-godaddy_api_key: "your_godaddy_api_key"
-godaddy_api_secret: "your_godaddy_api_secret"
-use_godaddy: true
-webroot_path: "/var/www/html"
+letsencrypt_setup_domain_name: "your_domain"
+letsencrypt_setup_email_address: "your_email"
+letsencrypt_setup_godaddy_api_key: "your_godaddy_api_key"
+letsencrypt_setup_godaddy_api_secret: "your_godaddy_api_secret"
+letsencrypt_setup_use_godaddy: true
+letsencrypt_setup_webroot_path: "/var/www/html"

--- a/src/roles/letsencrypt_setup/tasks/main.yml
+++ b/src/roles/letsencrypt_setup/tasks/main.yml
@@ -23,25 +23,25 @@
     src: ./godaddy.ini
     dest: ~/.secrets/certbot/godaddy.ini
     mode: '0600'
-  when: use_godaddy
+  when: letsencrypt_setup_use_godaddy
 
 - name: Generate certificate with DNS validation
   ansible.builtin.command:
     cmd: >-
       certbot certonly --dns-godaddy --dns-godaddy-credentials ~/.secrets/certbot/godaddy.ini
-      -d {{ domain_name }} --non-interactive --agree-tos --email {{ email_address }}
-    creates: "/etc/letsencrypt/live/{{ domain_name }}/privkey.pem"
+      -d {{ letsencrypt_setup_domain_name }} --non-interactive --agree-tos --email {{ letsencrypt_setup_email_address }}
+    creates: "/etc/letsencrypt/live/{{ letsencrypt_setup_domain_name }}/privkey.pem"
   become: true
-  when: use_godaddy
+  when: letsencrypt_setup_use_godaddy
 
 - name: Generate certificate with webroot validation
   ansible.builtin.command:
     cmd: >-
-      certbot certonly --webroot -w {{ webroot_path }} -d {{ domain_name }}
-      --non-interactive --agree-tos --email {{ email_address }}
-    creates: "/etc/letsencrypt/live/{{ domain_name }}/privkey.pem"
+      certbot certonly --webroot -w {{ letsencrypt_setup_webroot_path }} -d {{ letsencrypt_setup_domain_name }}
+      --non-interactive --agree-tos --email {{ letsencrypt_setup_email_address }}
+    creates: "/etc/letsencrypt/live/{{ letsencrypt_setup_domain_name }}/privkey.pem"
   become: true
-  when: not use_godaddy
+  when: not letsencrypt_setup_use_godaddy
 
 - name: Set up automatic renewal
   ansible.builtin.cron:

--- a/src/roles/mariadb_backups/defaults/main.yml
+++ b/src/roles/mariadb_backups/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-backup_script_path: "/usr/local/bin/mariadb-backup.sh"
-service_file_path: "/etc/systemd/system/mariadb-backup.service"
-mariadb_username: "backup_user"
-mariadb_password: "backup_password"
-backup_location: "/path/to/backup"
+mariadb_backups_backup_script_path: "/usr/local/bin/mariadb-backup.sh"
+mariadb_backups_service_file_path: "/etc/systemd/system/mariadb-backup.service"
+mariadb_backups_mariadb_username: "backup_user"
+mariadb_backups_mariadb_password: "backup_password"
+mariadb_backups_backup_location: "/path/to/backup"

--- a/src/roles/mariadb_backups/tasks/main.yml
+++ b/src/roles/mariadb_backups/tasks/main.yml
@@ -1,27 +1,27 @@
 ---
 - name: Install required packages
-  apt:
+  ansible.builtin.apt:
     name: ['mariadb-client', 'gzip']
     state: present
 
 - name: Copy MariaDB backup script
-  template:
+  ansible.builtin.template:
     src: mariadb-backup.sh.j2
-    dest: "{{ backup_script_path }}"
+    dest: "{{ mariadb_backups_backup_script_path }}"
     owner: root
     group: root
     mode: '0700'
 
 - name: Copy systemd service file
-  copy:
+  ansible.builtin.copy:
     src: mariadb-backup.service
-    dest: "{{ service_file_path }}"
+    dest: "{{ mariadb_backups_service_file_path }}"
     owner: root
     group: root
     mode: '0644'
 
 - name: Enable and start service
-  systemd:
+  ansible.builtin.systemd:
     name: mariadb-backup
-    enabled: yes
+    enabled: true
     state: started

--- a/src/roles/mariadb_backups/templates/mariadb-backup.sh.j2
+++ b/src/roles/mariadb_backups/templates/mariadb-backup.sh.j2
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mysqldump -u {{ mariadb_username }} -p{{ mariadb_password }} --all-databases | gzip > {{ backup_location }}/$(date +\%Y\%m\%d\%H\%M\%S).sql.gz
+mysqldump -u {{ mariadb_backups_mariadb_username }} -p{{ mariadb_backups_mariadb_password }} --all-databases | gzip > {{ mariadb_backups_backup_location }}/$(date +\%Y\%m\%d\%H\%M\%S).sql.gz

--- a/src/roles/mariadb_galera_loadbalancer_install/handlers/main.yml
+++ b/src/roles/mariadb_galera_loadbalancer_install/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 # Handler to restart GLB service when needed
-- name: restart glb
-  service:
+- name: Restart GLB
+  ansible.builtin.service:
     name: glb
     state: restarted

--- a/src/roles/spark_role/tasks/main.yml
+++ b/src/roles/spark_role/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
-- import_tasks: install.yml
-- import_tasks: config.yml
-- import_tasks: service.yml
+- name: Include install tasks
+  ansible.builtin.import_tasks: install.yml
+- name: Include config tasks
+  ansible.builtin.import_tasks: config.yml
+- name: Include service tasks
+  ansible.builtin.import_tasks: service.yml

--- a/src/roles/spark_role/tasks/service.yml
+++ b/src/roles/spark_role/tasks/service.yml
@@ -1,56 +1,56 @@
 ---
 - name: Deploy Spark Master unit
-  template:
+  ansible.builtin.template:
     src: spark-master.service.j2
     dest: /etc/systemd/system/spark-master.service
     mode: "0644"
   when: inventory_hostname in groups['spark_master']
   notify: Restart Spark Master
-  become: yes
+  become: true
 
 - name: Deploy Spark Worker unit
-  template:
+  ansible.builtin.template:
     src: spark-worker.service.j2
     dest: /etc/systemd/system/spark-worker.service
     mode: "0644"
   when: inventory_hostname in groups['spark_worker']
   notify: Restart Spark Worker
-  become: yes
+  become: true
 
 - name: Deploy Spark History Server unit
-  template:
+  ansible.builtin.template:
     src: spark-history-server.service.j2
     dest: /etc/systemd/system/spark-history-server.service
     mode: "0644"
   when: spark_history_enabled | bool and inventory_hostname in groups['spark_master']
   notify: Restart Spark History Server
-  become: yes
+  become: true
 
 - name: Reload systemd configuration
-  systemd:
-    daemon_reload: yes
-  become: yes
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true
 
 - name: Enable and start Spark Master
-  systemd:
+  ansible.builtin.systemd:
     name: spark-master
     state: started
-    enabled: yes
+    enabled: true
   when: inventory_hostname in groups['spark_master']
-  become: yes
+  become: true
 
 - name: Enable and start Spark Worker
-  systemd:
+  ansible.builtin.systemd:
     name: spark-worker
     state: started
-    enabled: yes
+    enabled: true
   when: inventory_hostname in groups['spark_worker']
-  become: yes
+  become: true
 
 - name: Enable and start Spark History Server
-  systemd:
+  ansible.builtin.systemd:
     name: spark-history-server
     state: started
-    enabled: yes
+    enabled: true
   when: spark_history_enabled | bool and inventory_hostname in groups['spark_master']
-  become: yes
+  become: true

--- a/src/roles/vault/handlers/main.yml
+++ b/src/roles/vault/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart vault
+- name: Restart Vault
   ansible.builtin.service:
     name: "{{ vault_service_name }}"
     state: restarted

--- a/src/roles/vault/tasks/install.yml
+++ b/src/roles/vault/tasks/install.yml
@@ -14,7 +14,10 @@
 
 - name: Add HashiCorp repository
   ansible.builtin.apt_repository:
-    repo: "deb [arch={{ ansible_architecture }} signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+    repo: >-
+      deb [arch={{ ansible_architecture }}
+      signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg]
+      https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main
     filename: hashicorp
     state: present
 
@@ -27,7 +30,7 @@
 - name: Create Vault user and group
   ansible.builtin.user:
     name: "{{ vault_user }}"
-    system: yes
+    system: true
     shell: /usr/sbin/nologin
   register: _vault_user_created
 


### PR DESCRIPTION
## Summary
- fix variable names in letsencrypt_setup role
- use FQCN modules and renamed vars in mariadb_backups
- clean up GLB handler
- add names and FQCNs for spark role
- fix Vault handler and repository config

## Testing
- `ansible-lint` *(fails: Failed to load elastic.yml playbook due to failing syntax check)*

------
https://chatgpt.com/codex/tasks/task_e_683cd7ce7d28832a95cf9aaa72977701