### PR TITLE
Fix some ansible-lint issues

### DIFF
--- a/src/roles/keepalived/handlers/main.yml
+++ b/src/roles/keepalived/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart keepalived
-  service:
+- name: Restart keepalived
+  ansible.builtin.service:
     name: "{{ keepalived_service_name }}"
     state: restarted

--- a/src/roles/keepalived/tasks/main.yml
+++ b/src/roles/keepalived/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Install keepalived
-  apt:
+  ansible.builtin.apt:
     name: "{{ keepalived_package_name }}"
     state: present
-  become: yes
+  become: true
   when: ansible_facts.os_family == 'Debian'
 
 - name: Deploy keepalived configuration
-  template:
+  ansible.builtin.template:
     src: keepalived.conf.j2
     dest: /etc/keepalived/keepalived.conf
     owner: root
@@ -16,7 +16,7 @@
   notify: restart keepalived
 
 - name: Enable and start keepalived
-  service:
+  ansible.builtin.service:
     name: "{{ keepalived_service_name }}"
     state: started
-    enabled: yes
+    enabled: true

--- a/src/roles/keepalived_setup/handlers/main.yml
+++ b/src/roles/keepalived_setup/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 # handlers file for keepalived_setup
-- name: restart keepalived
-  service:
+- name: Restart keepalived
+  ansible.builtin.service:
     name: keepalived
     state: restarted

--- a/src/roles/keepalived_setup/tasks/main.yml
+++ b/src/roles/keepalived_setup/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 # tasks file for keepalived_setup
 - name: Ensure keepalived is installed
-  apt:
+  ansible.builtin.apt:
     name: keepalived
     state: present
-    update_cache: yes
+    update_cache: true
 
 - name: Configure keepalived
-  template:
+  ansible.builtin.template:
     src: keepalived.conf.j2
     dest: /etc/keepalived/keepalived.conf
     owner: root

--- a/src/roles/spark_role/tasks/config.yml
+++ b/src/roles/spark_role/tasks/config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Deploy spark-env.sh
-  template:
+  ansible.builtin.template:
     src: spark-env.sh.j2
     dest: "{{ spark_symlink_dir }}/conf/spark-env.sh"
     owner: "{{ spark_user }}"
@@ -9,10 +9,10 @@
   notify:
     - Restart Spark Master
     - Restart Spark Worker
-  become: yes
+  become: true
 
 - name: Deploy spark-defaults.conf
-  template:
+  ansible.builtin.template:
     src: spark-defaults.conf.j2
     dest: "{{ spark_symlink_dir }}/conf/spark-defaults.conf"
     owner: "{{ spark_user }}"
@@ -21,14 +21,14 @@
   notify:
     - Restart Spark Master
     - Restart Spark Worker
-  become: yes
+  become: true
 
 - name: Deploy workers file
-  template:
+  ansible.builtin.template:
     src: workers.j2
     dest: "{{ spark_symlink_dir }}/conf/workers"
     owner: "{{ spark_user }}"
     group: "{{ spark_group }}"
     mode: "0644"
   when: groups['spark_worker'] is defined
-  become: yes
+  become: true

--- a/src/roles/spark_role/tasks/install.yml
+++ b/src/roles/spark_role/tasks/install.yml
@@ -1,61 +1,61 @@
 ---
 - name: Ensure spark group exists
-  group:
+  ansible.builtin.group:
     name: "{{ spark_group }}"
     state: present
-  become: yes
+  become: true
 
 - name: Ensure spark user exists
-  user:
+  ansible.builtin.user:
     name: "{{ spark_user }}"
     group: "{{ spark_group }}"
-    create_home: yes
+    create_home: true
     shell: /bin/bash
     state: present
-  become: yes
+  become: true
 
 - name: Install Java
-  apt:
+  ansible.builtin.apt:
     name: "{{ java_package }}"
     state: present
-    update_cache: yes
-  become: yes
+    update_cache: true
+  become: true
 
 - name: Create installation directory
-  file:
+  ansible.builtin.file:
     path: "{{ spark_install_dir }}"
     state: directory
     owner: "{{ spark_user }}"
     group: "{{ spark_group }}"
     mode: "0755"
-  become: yes
+  become: true
 
 - name: Download Spark archive
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ spark_download_url }}"
     dest: "{{ spark_install_dir }}/{{ spark_package_name }}.tgz"
     mode: "0644"
-    force: no
-  become: yes
+    force: false
+  become: true
 
 - name: Extract Spark archive
-  unarchive:
+  ansible.builtin.unarchive:
     src: "{{ spark_install_dir }}/{{ spark_package_name }}.tgz"
     dest: "{{ spark_install_dir }}"
-    remote_src: yes
+    remote_src: true
     creates: "{{ spark_install_dir }}/{{ spark_package_name }}/bin/spark-submit"
-  become: yes
+  become: true
 
 - name: Update Spark symlink
-  file:
+  ansible.builtin.file:
     src: "{{ spark_install_dir }}/{{ spark_package_name }}"
     dest: "{{ spark_symlink_dir }}"
     state: link
-    force: yes
-  become: yes
+    force: true
+  become: true
 
 - name: Ensure additional directories exist
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     owner: "{{ spark_user }}"
@@ -67,4 +67,4 @@
     - "{{ spark_worker_dir }}"
     - "{{ spark_recovery_dir | default(omit) }}"
   when: item is not none
-  become: yes
+  become: true


### PR DESCRIPTION
## Summary
- fix FQCN warnings and boolean syntax in keepalived roles
- fix handler names and modules for keepalived_setup
- update spark_role install and config tasks to follow ansible-lint recommendations

## Testing
- `ansible-lint` *(fails: 791 failure(s))*

------
https://chatgpt.com/codex/tasks/task_e_683cd9bb0990832aae65515b90d9c68c