### PR TITLE
Fix some ansible-lint warnings

### DIFF
--- a/src/roles/apache_nifi/tasks/main.yml
+++ b/src/roles/apache_nifi/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Include install tasks
-  import_tasks: install.yml
+  ansible.builtin.import_tasks: install.yml
 
 - name: Include configuration tasks
-  import_tasks: config.yml
+  ansible.builtin.import_tasks: config.yml
 
 - name: Include service tasks
-  import_tasks: service.yml
+  ansible.builtin.import_tasks: service.yml

--- a/src/roles/apache_nifi/tasks/service.yml
+++ b/src/roles/apache_nifi/tasks/service.yml
@@ -1,8 +1,8 @@
 ---
 - name: Enable and start NiFi service
   become: true
-  service:
+  ansible.builtin.service:
     name: nifi
-    enabled: yes
+    enabled: true
     state: started
   tags: [nifi, service]

--- a/src/roles/apache_superset/handlers/main.yml
+++ b/src/roles/apache_superset/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: restart superset
+- name: Restart superset
   ansible.builtin.systemd:
     name: "{{ superset_service_name }}"
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true

--- a/src/roles/apache_superset/tasks/init_db.yml
+++ b/src/roles/apache_superset/tasks/init_db.yml
@@ -6,6 +6,7 @@
     SUPERSET_CONFIG_PATH: "{{ superset_config_path }}"
   changed_when: false
   become_user: "{{ superset_user }}"
+  become: true
 
 - name: Create admin user
   ansible.builtin.command: >
@@ -21,6 +22,7 @@
     FLASK_APP: superset
     SUPERSET_CONFIG_PATH: "{{ superset_config_path }}"
   become_user: "{{ superset_user }}"
+  become: true
 
 - name: Touch marker file after admin creation
   ansible.builtin.file:
@@ -29,7 +31,7 @@
     owner: "{{ superset_user }}"
     group: "{{ superset_group }}"
   when: not (superset_marker_file is exists)
-  become: yes
+  become: true
 
 - name: Load example data
   ansible.builtin.command: "{{ superset_venv_dir }}/bin/superset load_examples"
@@ -38,6 +40,7 @@
     SUPERSET_CONFIG_PATH: "{{ superset_config_path }}"
   when: superset_load_examples | bool
   become_user: "{{ superset_user }}"
+  become: true
 
 - name: Initialize roles and permissions
   ansible.builtin.command: "{{ superset_venv_dir }}/bin/superset init"
@@ -46,3 +49,4 @@
     SUPERSET_CONFIG_PATH: "{{ superset_config_path }}"
   changed_when: false
   become_user: "{{ superset_user }}"
+  become: true

--- a/src/roles/apache_superset/tasks/install.yml
+++ b/src/roles/apache_superset/tasks/install.yml
@@ -16,5 +16,5 @@
   ansible.builtin.apt:
     name: "{{ superset_system_packages }}"
     state: present
-    update_cache: yes
+    update_cache: true
   become: yes

--- a/src/roles/apache_superset/tasks/service.yml
+++ b/src/roles/apache_superset/tasks/service.yml
@@ -9,12 +9,12 @@
 
 - name: Reload systemd
   ansible.builtin.systemd:
-    daemon_reload: yes
+    daemon_reload: true
   become: yes
 
 - name: Enable and start Superset service
   ansible.builtin.systemd:
     name: "{{ superset_service_name }}"
-    enabled: yes
+    enabled: true
     state: started
   become: yes

--- a/src/roles/python_git_repo_service_install/tasks/main.yml
+++ b/src/roles/python_git_repo_service_install/tasks/main.yml
@@ -1,23 +1,24 @@
 ---
 - name: Clone Git repository
-  git:
+  ansible.builtin.git:
     repo: "{{ app_repo }}"
     dest: "/opt/{{ app_name }}"
+    version: "{{ app_version | default('HEAD') }}"
   register: git_output
 
 - name: Install Python dependencies
-  pip:
+  ansible.builtin.pip:
     requirements: "/opt/{{ app_name }}/requirements.txt"
 
 - name: Configure systemd service
-  template:
+  ansible.builtin.template:
     src: "templates/app.service.j2"
     dest: "/etc/systemd/system/{{ app_name }}.service"
   notify:
     - Reload systemd
 
 - name: Start and enable the application service
-  systemd:
+  ansible.builtin.systemd:
     name: "{{ app_name }}"
     state: started
-    enabled: yes
+    enabled: true

--- a/src/roles/remove_unnecessary_packages/tasks/main.yml
+++ b/src/roles/remove_unnecessary_packages/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Retry removing unnecessary packages
   block:
     - name: Remove unnecessary packages
-      apt:
+      ansible.builtin.apt:
         name: "{{ item }}"
         state: absent
       loop: "{{ unnecessary_packages }}"
@@ -12,5 +12,5 @@
       delay: 10
   rescue:
     - name: Handle failure
-      debug:
+      ansible.builtin.debug:
         msg: "Failed to remove unnecessary packages"


### PR DESCRIPTION
## Summary
- update some tasks to use FQCN syntax
- replace legacy truthy values with booleans
- ensure become is paired with become_user
- add version for git checkout

## Testing
- `ANSIBLE_LINT_NODEPS=1 ansible-lint --offline -p playbooks/site.yml`


------
https://chatgpt.com/codex/tasks/task_e_683db132bc00832aab16f0b5fd6da30d