### PR TITLE
Fix ansible lint issues

### DIFF
--- a/src/inventories/production/group_vars/all.yml
+++ b/src/inventories/production/group_vars/all.yml
@@ -1,6 +1,6 @@
 ---
 es_cluster_name: "prod-es-cluster"
-elasticsearch_version: "8.8.0"
+elasticsearch_install_version: "8.8.0"
 
 # Snapshot settings
 es_snapshot_repo_name: "backup_repo"
@@ -8,7 +8,7 @@ es_snapshot_repo_type: "fs"
 es_snapshot_repo_settings:
   location: "/mnt/elasticsearch_snapshots"
   compress: true
-es_use_slm: true
+elasticsearch_snapshot_use_slm: true
 
 # LDAP settings
 ldap_url: "ldaps://ldap.example.com:636"

--- a/src/inventories/production/group_vars/es_coord.yml
+++ b/src/inventories/production/group_vars/es_coord.yml
@@ -2,4 +2,4 @@
 node_roles:
   - remote_cluster_client
   - ingest
-elasticsearch_heap_size: "4g"
+  elasticsearch_config_heap_size: "4g"

--- a/src/inventories/production/group_vars/es_data.yml
+++ b/src/inventories/production/group_vars/es_data.yml
@@ -1,4 +1,4 @@
 ---
 node_roles:
   - data
-elasticsearch_heap_size: "8g"
+  elasticsearch_config_heap_size: "8g"

--- a/src/inventories/production/group_vars/es_master.yml
+++ b/src/inventories/production/group_vars/es_master.yml
@@ -1,4 +1,4 @@
 ---
 node_roles:
   - master
-elasticsearch_heap_size: "2g"
+  elasticsearch_config_heap_size: "2g"

--- a/src/roles/elasticsearch_config/defaults/main.yml
+++ b/src/roles/elasticsearch_config/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-elasticsearch_heap_size: "2g"
+elasticsearch_config_heap_size: "2g"

--- a/src/roles/elasticsearch_config/tasks/config.yml
+++ b/src/roles/elasticsearch_config/tasks/config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Template elasticsearch.yml
-  template:
+  ansible.builtin.template:
     src: elasticsearch.yml.j2
     dest: /etc/elasticsearch/elasticsearch.yml
     owner: root

--- a/src/roles/elasticsearch_config/tasks/jvm.yml
+++ b/src/roles/elasticsearch_config/tasks/jvm.yml
@@ -1,6 +1,6 @@
 ---
 - name: Template JVM options
-  template:
+  ansible.builtin.template:
     src: jvm.options.j2
     dest: /etc/elasticsearch/jvm.options.d/heap.options
     owner: root

--- a/src/roles/elasticsearch_config/tasks/main.yml
+++ b/src/roles/elasticsearch_config/tasks/main.yml
@@ -1,3 +1,6 @@
 ---
-- import_tasks: config.yml
-- import_tasks: jvm.yml
+- name: Import configuration tasks
+  ansible.builtin.import_tasks: config.yml
+
+- name: Import JVM configuration tasks
+  ansible.builtin.import_tasks: jvm.yml

--- a/src/roles/elasticsearch_config/templates/jvm.options.j2
+++ b/src/roles/elasticsearch_config/templates/jvm.options.j2
@@ -1,2 +1,2 @@
--Xms{{ elasticsearch_heap_size }}
--Xmx{{ elasticsearch_heap_size }}
+-Xms{{ elasticsearch_config_heap_size }}
+-Xmx{{ elasticsearch_config_heap_size }}

--- a/src/roles/elasticsearch_install/defaults/main.yml
+++ b/src/roles/elasticsearch_install/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-elasticsearch_version: "8.8.0"
-java_install: true
+elasticsearch_install_version: "8.8.0"
+elasticsearch_install_java_install: true

--- a/src/roles/elasticsearch_install/handlers/main.yml
+++ b/src/roles/elasticsearch_install/handlers/main.yml
@@ -1,9 +1,9 @@
 ---
-- name: update apt cache
-  apt:
-    update_cache: yes
+- name: Update APT cache
+  ansible.builtin.apt:
+    update_cache: true
 
-- name: restart elasticsearch
-  service:
+- name: Restart Elasticsearch
+  ansible.builtin.service:
     name: elasticsearch
     state: restarted

--- a/src/roles/elasticsearch_install/meta/main.yml
+++ b/src/roles/elasticsearch_install/meta/main.yml
@@ -12,4 +12,4 @@ galaxy_info:
       versions: [focal, jammy]
 dependencies:
   - role: geerlingguy.java
-    when: java_install | default(true)
+    when: elasticsearch_install_java_install | default(true)

--- a/src/roles/elasticsearch_install/tasks/install.yml
+++ b/src/roles/elasticsearch_install/tasks/install.yml
@@ -1,25 +1,25 @@
 ---
 - name: Ensure apt-transport-https is installed
-  apt:
+  ansible.builtin.apt:
     name: apt-transport-https
     state: present
-    update_cache: yes
+    update_cache: true
 
 - name: Add Elasticsearch GPG key
-  apt_key:
+  ansible.builtin.apt_key:
     url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
     state: present
 
 - name: Add Elasticsearch repository
-  template:
+  ansible.builtin.template:
     src: elasticsearch.list.j2
     dest: /etc/apt/sources.list.d/elasticsearch.list
     mode: '0644'
   notify: update apt cache
 
 - name: Install Elasticsearch
-  apt:
-    name: "elasticsearch={{ elasticsearch_version }}"
+  ansible.builtin.apt:
+    name: "elasticsearch={{ elasticsearch_install_version }}"
     state: present
-    update_cache: yes
+    update_cache: true
   notify: restart elasticsearch

--- a/src/roles/elasticsearch_install/templates/elasticsearch.list.j2
+++ b/src/roles/elasticsearch_install/templates/elasticsearch.list.j2
@@ -1,1 +1,1 @@
-deb [trusted=yes] https://artifacts.elastic.co/packages/{{ elasticsearch_version | regex_replace('\\..*$', '') }}/apt stable main
+deb [trusted=yes] https://artifacts.elastic.co/packages/{{ elasticsearch_install_version | regex_replace('\\..*$', '') }}/apt stable main

--- a/src/roles/elasticsearch_snapshot/defaults/main.yml
+++ b/src/roles/elasticsearch_snapshot/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-es_use_slm: true
+elasticsearch_snapshot_use_slm: true

--- a/src/roles/elasticsearch_snapshot/tasks/cron.yml
+++ b/src/roles/elasticsearch_snapshot/tasks/cron.yml
@@ -1,17 +1,17 @@
 ---
-- name: Install snapshot script
-  template:
+ - name: Install snapshot script
+   ansible.builtin.template:
     src: snapshot_script.sh.j2
     dest: /usr/local/bin/es_snapshot.sh
     mode: '0750'
     owner: root
     group: root
 
-- name: Schedule snapshot via cron
-  cron:
+ - name: Schedule snapshot via cron
+   ansible.builtin.cron:
     name: "Elasticsearch Daily Snapshot"
     hour: 2
     minute: 0
     user: root
     job: "/usr/local/bin/es_snapshot.sh"
-  when: es_use_slm is not true
+   when: elasticsearch_snapshot_use_slm is not true


### PR DESCRIPTION
## Summary
- cleanup lint warnings in elasticsearch roles
- rename variables with proper prefixes
- use fully-qualified module names

## Testing
- `ansible-lint` *(fails: 552 failure(s))*

------
https://chatgpt.com/codex/tasks/task_e_683db3bad4d0832abfca987c5752cf51