### PR TITLE
Fix ansible-lint errors

### DIFF
--- a/src/roles/elasticsearch/handlers/main.yml
+++ b/src/roles/elasticsearch/handlers/main.yml
@@ -1,10 +1,10 @@
 ---
-- name: update apt cache
-  apt:
-    update_cache: yes
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
 
-- name: restart elasticsearch
-  service:
+- name: Restart elasticsearch
+  ansible.builtin.service:
     name: elasticsearch
     state: restarted
-    enabled: yes
+    enabled: true

--- a/src/roles/elasticsearch/tasks/config.yml
+++ b/src/roles/elasticsearch/tasks/config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Template elasticsearch.yml
-  template:
+  ansible.builtin.template:
     src: elasticsearch.yml.j2
     dest: /etc/elasticsearch/elasticsearch.yml
     owner: root
@@ -9,7 +9,7 @@
   notify: restart elasticsearch
 
 - name: Template JVM options
-  template:
+  ansible.builtin.template:
     src: jvm.options.j2
     dest: /etc/elasticsearch/jvm.options.d/heap.options
     owner: root

--- a/src/roles/elasticsearch/tasks/install.yml
+++ b/src/roles/elasticsearch/tasks/install.yml
@@ -1,37 +1,37 @@
 ---
 - name: Ensure apt-transport-https is installed
-  apt:
+  ansible.builtin.apt:
     name: apt-transport-https
     state: present
-    update_cache: yes
+    update_cache: true
 
 - name: Add Elasticsearch GPG key
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
 
 - name: Add Elasticsearch repository
-  template:
+  ansible.builtin.template:
     src: elasticsearch.list.j2
     dest: /etc/apt/sources.list.d/elasticsearch.list
     mode: '0644'
   notify: update apt cache
 
 - name: Install OpenJDK
-  apt:
+  ansible.builtin.apt:
     name: openjdk-11-jdk
     state: present
   when: es_install_java
 
 - name: Install Elasticsearch
-  apt:
+  ansible.builtin.apt:
     name: elasticsearch
     state: present
-    update_cache: yes
+    update_cache: true
   notify: restart elasticsearch
 
 - name: Ensure Elasticsearch service enabled and started
-  service:
+  ansible.builtin.service:
     name: elasticsearch
     state: started
-    enabled: yes
+    enabled: true

--- a/src/roles/elasticsearch/tasks/main.yml
+++ b/src/roles/elasticsearch/tasks/main.yml
@@ -1,10 +1,13 @@
 ---
-- import_tasks: install.yml
+- name: Include install tasks
+  ansible.builtin.import_tasks: install.yml
   tags: install
 
-- import_tasks: config.yml
+- name: Include config tasks
+  ansible.builtin.import_tasks: config.yml
   tags: config
 
-- import_tasks: security.yml
+- name: Include security tasks
+  ansible.builtin.import_tasks: security.yml
   when: es_enable_security
   tags: security

--- a/src/roles/elasticsearch/tasks/security.yml
+++ b/src/roles/elasticsearch/tasks/security.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure certificate directory exists
-  file:
+  ansible.builtin.file:
     path: /etc/elasticsearch/certs
     state: directory
     owner: root
@@ -8,7 +8,7 @@
     mode: '0750'
 
 - name: Copy node certificate
-  copy:
+  ansible.builtin.copy:
     src: "{{ inventory_hostname }}.crt"
     dest: "/etc/elasticsearch/certs/{{ inventory_hostname }}.crt"
     owner: root
@@ -17,7 +17,7 @@
   when: es_tls_provided
 
 - name: Copy node key
-  copy:
+  ansible.builtin.copy:
     src: "{{ inventory_hostname }}.key"
     dest: "/etc/elasticsearch/certs/{{ inventory_hostname }}.key"
     owner: root
@@ -26,7 +26,7 @@
   when: es_tls_provided
 
 - name: Copy CA certificate
-  copy:
+  ansible.builtin.copy:
     src: cacert.pem
     dest: /etc/elasticsearch/certs/ca.crt
     owner: root
@@ -35,7 +35,7 @@
   when: es_tls_provided
 
 - name: Configure TLS settings
-  blockinfile:
+  ansible.builtin.blockinfile:
     path: /etc/elasticsearch/elasticsearch.yml
     block: |
       xpack.security.enabled: true
@@ -48,7 +48,7 @@
   when: es_tls_provided
 
 - name: Configure LDAP realm
-  blockinfile:
+  ansible.builtin.blockinfile:
     path: /etc/elasticsearch/elasticsearch.yml
     block: |
       xpack.security.authc.realms.ldap.ldap1:
@@ -64,7 +64,7 @@
   notify: restart elasticsearch
 
 - name: Template role mapping file
-  template:
+  ansible.builtin.template:
     src: role_mapping.yml.j2
     dest: /etc/elasticsearch/role_mapping.yml
     owner: root


### PR DESCRIPTION
## Summary
- address many ansible-lint warnings
- ensure modules use FQCN
- fix truthy values and task names

## Testing
- `ansible-lint src/roles/elasticsearch`

------
https://chatgpt.com/codex/tasks/task_e_683db5de64d8832abd98b80f0b8bbb5e