### PR TITLE
Fix ansible-lint warnings

### DIFF
--- a/src/roles/amundsen_frontend/tasks/main.yml
+++ b/src/roles/amundsen_frontend/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.user:
     name: amundsen
     shell: /usr/sbin/nologin
-  become: yes
+  become: true
 
 - name: Create frontend directories
   ansible.builtin.file:
@@ -14,20 +14,20 @@
     mode: "0755"
   loop:
     - "{{ frontend_virtualenv | dirname }}"
-  become: yes
+  become: true
 
 - name: Create virtualenv for frontend
   ansible.builtin.command: python3 -m venv "{{ frontend_virtualenv }}"
   args:
     creates: "{{ frontend_virtualenv }}/bin/activate"
-  become: yes
+  become: true
 
 - name: Install frontend service
   ansible.builtin.pip:
     virtualenv: "{{ frontend_virtualenv }}"
     name: "amundsen-frontend=={{ amundsen_frontend_version }}"
     state: present
-  become: yes
+  become: true
 
 - name: Deploy frontend config
   ansible.builtin.template:
@@ -36,7 +36,7 @@
     owner: amundsen
     group: amundsen
     mode: "0644"
-  become: yes
+  become: true
   notify: Restart Frontend Service
 
 - name: Deploy systemd unit
@@ -44,12 +44,12 @@
     src: frontend_gunicorn.service.j2
     dest: /etc/systemd/system/amundsen-frontend.service
     mode: "0644"
-  become: yes
+  become: true
   notify: Reload Systemd
 
 - name: Enable and start service
   ansible.builtin.systemd:
     name: amundsen-frontend
-    enabled: yes
+    enabled: true
     state: started
-  become: yes
+  become: true

--- a/src/roles/apache_nifi/tasks/config.yml
+++ b/src/roles/apache_nifi/tasks/config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Deploy nifi.properties
   become: true
-  template:
+  ansible.builtin.template:
     src: nifi.properties.j2
     dest: "{{ nifi_conf_dir }}/nifi.properties"
     owner: "{{ nifi_user }}"
@@ -12,7 +12,7 @@
 
 - name: Deploy bootstrap.conf
   become: true
-  template:
+  ansible.builtin.template:
     src: bootstrap.conf.j2
     dest: "{{ nifi_conf_dir }}/bootstrap.conf"
     owner: "{{ nifi_user }}"
@@ -23,7 +23,7 @@
 
 - name: Deploy login-identity-providers.xml
   become: true
-  template:
+  ansible.builtin.template:
     src: login-identity-providers.xml.j2
     dest: "{{ nifi_conf_dir }}/login-identity-providers.xml"
     owner: "{{ nifi_user }}"
@@ -34,7 +34,7 @@
 
 - name: Deploy authorizers.xml
   become: true
-  template:
+  ansible.builtin.template:
     src: authorizers.xml.j2
     dest: "{{ nifi_conf_dir }}/authorizers.xml"
     owner: "{{ nifi_user }}"
@@ -44,15 +44,14 @@
   tags: [nifi, config]
 
 - name: Install Filebeat for ELK (optional)
-  become: true
-  include_role:
+  ansible.builtin.include_role:
     name: elastic.filebeat
   when: nifi_elk_integration
   tags: [nifi, elk]
 
 - name: Configure Filebeat for NiFi logs (optional)
   become: true
-  template:
+  ansible.builtin.template:
     src: filebeat-nifi.yml.j2
     dest: /etc/filebeat/conf.d/nifi.yml
     mode: '0644'

--- a/src/roles/apache_nifi/tasks/install.yml
+++ b/src/roles/apache_nifi/tasks/install.yml
@@ -1,31 +1,31 @@
 ---
 - name: Ensure Java is present
   become: true
-  apt:
+  ansible.builtin.apt:
     name: openjdk-11-jdk
     state: present
   tags: [nifi, java]
 
 - name: Create nifi group
   become: true
-  group:
+  ansible.builtin.group:
     name: "{{ nifi_group }}"
     state: present
   tags: [nifi, users]
 
 - name: Create nifi user
   become: true
-  user:
+  ansible.builtin.user:
     name: "{{ nifi_user }}"
     group: "{{ nifi_group }}"
     home: "{{ nifi_home }}"
     shell: /usr/sbin/nologin
-    system: yes
+    system: true
   tags: [nifi, users]
 
 - name: Add NiFi APT repository
   become: true
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "{{ nifi_apt_repo }}"
     state: present
   when: nifi_use_apt_repo
@@ -36,13 +36,13 @@
   ansible.builtin.apt:
     name: nifi
     state: present
-    update_cache: yes
+    update_cache: true
   when: nifi_install_method == "package"
   tags: [nifi, install]
 
 - name: Download NiFi tarball
   become: true
-  get_url:
+  ansible.builtin.get_url:
     url: "https://archive.apache.org/dist/nifi/{{ nifi_version }}/nifi-{{ nifi_version }}-bin.tar.gz"
     dest: "/tmp/nifi-{{ nifi_version }}.tar.gz"
     mode: '0644'
@@ -51,20 +51,20 @@
 
 - name: Extract NiFi tarball
   become: true
-  unarchive:
+  ansible.builtin.unarchive:
     src: "/tmp/nifi-{{ nifi_version }}.tar.gz"
     dest: "{{ nifi_home }}"
-    remote_src: yes
+    remote_src: true
     creates: "{{ nifi_home }}/bin/nifi.sh"
   when: nifi_install_method == "tarball"
   tags: [nifi, install]
 
 - name: Ensure correct ownership
   become: true
-  file:
+  ansible.builtin.file:
     path: "{{ nifi_home }}"
     state: directory
-    recurse: yes
+    recurse: true
     owner: "{{ nifi_user }}"
     group: "{{ nifi_group }}"
   tags: [nifi, permissions]


### PR DESCRIPTION
## Summary
- update Apache NiFi tasks to use FQCN modules and booleans
- clean up Filebeat configuration step
- replace 'yes' with `true` in Amundsen frontend role

## Testing
- `ansible-lint src/roles/apache_nifi src/roles/amundsen_frontend -q | head`

------
https://chatgpt.com/codex/tasks/task_e_683dc3146f64832a8958451639837a9d