### PR TITLE
Fix multiple ansible-lint warnings

### DIFF
--- a/src/roles/prometheus/tasks/configure.yml
+++ b/src/roles/prometheus/tasks/configure.yml
@@ -1,46 +1,46 @@
 ---
 - name: Ensure Prometheus data directory exists
-  file:
+  ansible.builtin.file:
     path: "{{ prometheus_data_dir }}"
     state: directory
     owner: prometheus
     group: prometheus
     mode: '0755'
-  become: yes
+  become: true
 
 - name: Deploy Prometheus configuration
-  template:
+  ansible.builtin.template:
     src: prometheus.yml.j2
     dest: /etc/prometheus/prometheus.yml
     owner: root
     group: prometheus
     mode: '0644'
   notify: Restart Prometheus
-  become: yes
+  become: true
 
 - name: Deploy alert rules file
-  template:
+  ansible.builtin.template:
     src: alert_rules.yml.j2
     dest: "{{ prometheus_rules_file }}"
     owner: root
     group: prometheus
     mode: '0644'
   notify: Restart Prometheus
-  become: yes
+  become: true
 
 - name: Install systemd unit override
-  template:
+  ansible.builtin.template:
     src: prometheus.service.j2
     dest: /etc/systemd/system/prometheus.service
     owner: root
     group: root
     mode: '0644'
   notify: Restart Prometheus
-  become: yes
+  become: true
 
 - name: Enable and start Prometheus service
-  service:
+  ansible.builtin.service:
     name: prometheus
     state: started
-    enabled: yes
-  become: yes
+    enabled: true
+  become: true

--- a/src/roles/prometheus/tasks/exporters.yml
+++ b/src/roles/prometheus/tasks/exporters.yml
@@ -1,8 +1,8 @@
 ---
 - name: Ensure Node Exporter service is enabled and started
-  service:
+  ansible.builtin.service:
     name: prometheus-node-exporter
     state: started
-    enabled: yes
-  become: yes
+    enabled: true
+  become: true
   tags: exporters

--- a/src/roles/prometheus/tasks/install.yml
+++ b/src/roles/prometheus/tasks/install.yml
@@ -1,8 +1,8 @@
 ---
 - name: Update apt cache
   ansible.builtin.apt:
-    update_cache: yes
-  become: yes
+    update_cache: true
+  become: true
 
 - name: Install Prometheus and Node Exporter
   ansible.builtin.apt:
@@ -10,5 +10,5 @@
       - prometheus
       - prometheus-node-exporter
     state: present
-  become: yes
+  become: true
   tags: install

--- a/src/roles/prometheus/tasks/main.yml
+++ b/src/roles/prometheus/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
-- import_tasks: install.yml
-- import_tasks: configure.yml
-- import_tasks: exporters.yml
+- name: Include install tasks
+  ansible.builtin.import_tasks: install.yml
+- name: Include configuration tasks
+  ansible.builtin.import_tasks: configure.yml
+- name: Include exporter tasks
+  ansible.builtin.import_tasks: exporters.yml

--- a/src/roles/python_git_repo_service_install/handlers/main.yml
+++ b/src/roles/python_git_repo_service_install/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: Reload systemd
-  systemd:
-    daemon_reload: yes
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/src/roles/python_git_repo_service_install/tasks/main.yml
+++ b/src/roles/python_git_repo_service_install/tasks/main.yml
@@ -14,6 +14,7 @@
   ansible.builtin.template:
     src: "templates/app.service.j2"
     dest: "/etc/systemd/system/{{ app_name }}.service"
+    mode: '0644'
   notify:
     - Reload systemd
 


### PR DESCRIPTION
## Summary
- address ansible-lint warnings in Prometheus role
- fix issues in python_git_repo_service_install role

## Testing
- `ansible-lint src/roles/prometheus/tasks/main.yml src/roles/prometheus/tasks/install.yml src/roles/prometheus/tasks/configure.yml src/roles/prometheus/tasks/exporters.yml src/roles/python_git_repo_service_install/handlers/main.yml src/roles/python_git_repo_service_install/tasks/main.yml`
- `ansible-lint -p | head -n 20` *(fails: the repo still has many lint errors overall)*

------
https://chatgpt.com/codex/tasks/task_e_683dc5376114832a8bdb81f60b8a68be