### PR TITLE
Fix ansible-lint issues in Amundsen roles

### DIFF
--- a/src/playbooks/site.yml
+++ b/src/playbooks/site.yml
@@ -1,3 +1,6 @@
 ---
-- import_playbook: ldap-servers.yml
-- import_playbook: ldap-clients.yml
+- name: Include LDAP servers playbook
+  import_playbook: ldap-servers.yml
+
+- name: Include LDAP clients playbook
+  import_playbook: ldap-clients.yml

--- a/src/roles/amundsen_frontend/defaults/main.yml
+++ b/src/roles/amundsen_frontend/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 amundsen_frontend_version: "4.0.0"
-frontend_bind_host: "0.0.0.0"
-frontend_port: 5000
-frontend_gunicorn_workers: 4
-frontend_virtualenv: "/opt/amundsen/frontend/venv"
-metadata_api_base: "http://localhost:5002"
-search_api_base: "http://localhost:5001"
-frontend_config_class: "amundsen_application.config.ProdConfig"
+amundsen_frontend_bind_host: "0.0.0.0"
+amundsen_frontend_port: 5000
+amundsen_frontend_gunicorn_workers: 4
+amundsen_frontend_virtualenv: "/opt/amundsen/frontend/venv"
+amundsen_frontend_metadata_api_base: "http://localhost:5002"
+amundsen_frontend_search_api_base: "http://localhost:5001"
+amundsen_frontend_config_class: "amundsen_application.config.ProdConfig"

--- a/src/roles/amundsen_frontend/tasks/main.yml
+++ b/src/roles/amundsen_frontend/tasks/main.yml
@@ -13,18 +13,18 @@
     group: amundsen
     mode: "0755"
   loop:
-    - "{{ frontend_virtualenv | dirname }}"
+    - "{{ amundsen_frontend_virtualenv | dirname }}"
   become: true
 
 - name: Create virtualenv for frontend
-  ansible.builtin.command: python3 -m venv "{{ frontend_virtualenv }}"
+  ansible.builtin.command: python3 -m venv "{{ amundsen_frontend_virtualenv }}"
   args:
-    creates: "{{ frontend_virtualenv }}/bin/activate"
+    creates: "{{ amundsen_frontend_virtualenv }}/bin/activate"
   become: true
 
 - name: Install frontend service
   ansible.builtin.pip:
-    virtualenv: "{{ frontend_virtualenv }}"
+    virtualenv: "{{ amundsen_frontend_virtualenv }}"
     name: "amundsen-frontend=={{ amundsen_frontend_version }}"
     state: present
   become: true
@@ -32,7 +32,7 @@
 - name: Deploy frontend config
   ansible.builtin.template:
     src: frontend_config.py.j2
-    dest: "{{ frontend_virtualenv }}/config.py"
+    dest: "{{ amundsen_frontend_virtualenv }}/config.py"
     owner: amundsen
     group: amundsen
     mode: "0644"

--- a/src/roles/amundsen_frontend/templates/frontend_config.py.j2
+++ b/src/roles/amundsen_frontend/templates/frontend_config.py.j2
@@ -1,6 +1,6 @@
 from amundsen_application.config import LocalConfig
 
 class ProdConfig(LocalConfig):
-    SEARCHSERVICE_BASE = "{{ search_api_base }}"
-    METADATASERVICE_BASE = "{{ metadata_api_base }}"
+    SEARCHSERVICE_BASE = "{{ amundsen_frontend_search_api_base }}"
+    METADATASERVICE_BASE = "{{ amundsen_frontend_metadata_api_base }}"
     LOG_LEVEL = "INFO"

--- a/src/roles/amundsen_frontend/templates/frontend_gunicorn.service.j2
+++ b/src/roles/amundsen_frontend/templates/frontend_gunicorn.service.j2
@@ -5,10 +5,10 @@ After=network.target
 [Service]
 User=amundsen
 Group=amundsen
-Environment=FRONTEND_SVC_CONFIG_MODULE_CLASS={{ frontend_config_class }}
-Environment=SEARCHSERVICE_BASE={{ search_api_base }}
-Environment=METADATASERVICE_BASE={{ metadata_api_base }}
-ExecStart={{ frontend_virtualenv }}/bin/gunicorn --workers {{ frontend_gunicorn_workers }} --bind {{ frontend_bind_host }}:{{ frontend_port }} amundsen_application.wsgi:app
+Environment=FRONTEND_SVC_CONFIG_MODULE_CLASS={{ amundsen_frontend_config_class }}
+Environment=SEARCHSERVICE_BASE={{ amundsen_frontend_search_api_base }}
+Environment=METADATASERVICE_BASE={{ amundsen_frontend_metadata_api_base }}
+ExecStart={{ amundsen_frontend_virtualenv }}/bin/gunicorn --workers {{ amundsen_frontend_gunicorn_workers }} --bind {{ amundsen_frontend_bind_host }}:{{ amundsen_frontend_port }} amundsen_application.wsgi:app
 Restart=always
 RestartSec=5
 

--- a/src/roles/amundsen_metadata/defaults/main.yml
+++ b/src/roles/amundsen_metadata/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
 amundsen_metadata_version: "4.0.0"
-metadata_bind_host: "0.0.0.0"
-metadata_port: 5002
-metadata_gunicorn_workers: 4
-metadata_virtualenv: "/opt/amundsen/metadata/venv"
-neo4j_host: "localhost"
-neo4j_port: 7687
-neo4j_user: "neo4j"
-neo4j_password: "ChangeMe!"
-metadata_config_class: "metadata_service.config.ProdConfig"
+amundsen_metadata_bind_host: "0.0.0.0"
+amundsen_metadata_port: 5002
+amundsen_metadata_gunicorn_workers: 4
+amundsen_metadata_virtualenv: "/opt/amundsen/metadata/venv"
+amundsen_metadata_neo4j_host: "localhost"
+amundsen_metadata_neo4j_port: 7687
+amundsen_metadata_neo4j_user: "neo4j"
+amundsen_metadata_neo4j_password: "ChangeMe!"
+amundsen_metadata_config_class: "metadata_service.config.ProdConfig"

--- a/src/roles/amundsen_metadata/tasks/main.yml
+++ b/src/roles/amundsen_metadata/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.user:
     name: amundsen
     shell: /usr/sbin/nologin
-  become: yes
+  become: true
 
 - name: Create metadata directories
   ansible.builtin.file:
@@ -13,30 +13,30 @@
     group: amundsen
     mode: "0755"
   loop:
-    - "{{ metadata_virtualenv | dirname }}"
-  become: yes
+    - "{{ amundsen_metadata_virtualenv | dirname }}"
+  become: true
 
 - name: Create virtualenv for metadata service
-  ansible.builtin.command: python3 -m venv "{{ metadata_virtualenv }}"
+  ansible.builtin.command: python3 -m venv "{{ amundsen_metadata_virtualenv }}"
   args:
-    creates: "{{ metadata_virtualenv }}/bin/activate"
-  become: yes
+    creates: "{{ amundsen_metadata_virtualenv }}/bin/activate"
+  become: true
 
 - name: Install metadata service
   ansible.builtin.pip:
-    virtualenv: "{{ metadata_virtualenv }}"
+    virtualenv: "{{ amundsen_metadata_virtualenv }}"
     name: "amundsen-metadata=={{ amundsen_metadata_version }}"
     state: present
-  become: yes
+  become: true
 
 - name: Deploy metadata config
   ansible.builtin.template:
     src: metadata_config.py.j2
-    dest: "{{ metadata_virtualenv }}/config.py"
+    dest: "{{ amundsen_metadata_virtualenv }}/config.py"
     owner: amundsen
     group: amundsen
     mode: "0644"
-  become: yes
+  become: true
   notify: Restart Metadata Service
 
 - name: Deploy systemd unit
@@ -44,12 +44,12 @@
     src: metadata_gunicorn.service.j2
     dest: /etc/systemd/system/amundsen-metadata.service
     mode: "0644"
-  become: yes
+  become: true
   notify: Reload Systemd
 
 - name: Enable and start service
   ansible.builtin.systemd:
     name: amundsen-metadata
-    enabled: yes
+    enabled: true
     state: started
-  become: yes
+  become: true

--- a/src/roles/amundsen_metadata/templates/metadata_config.py.j2
+++ b/src/roles/amundsen_metadata/templates/metadata_config.py.j2
@@ -3,9 +3,9 @@ from metadata_service.config_common import Config
 
 class ProdConfig(Config):
     # Neo4j
-    NEO4J_ENDPOINT = "bolt://{{ neo4j_host }}:{{ neo4j_port }}"
-    NEO4J_USERNAME = "{{ neo4j_user }}"
-    NEO4J_PASSWORD = "{{ neo4j_password }}"
+    NEO4J_ENDPOINT = "bolt://{{ amundsen_metadata_neo4j_host }}:{{ amundsen_metadata_neo4j_port }}"
+    NEO4J_USERNAME = "{{ amundsen_metadata_neo4j_user }}"
+    NEO4J_PASSWORD = "{{ amundsen_metadata_neo4j_password }}"
 
     # Logging
     LOG_LEVEL = "INFO"

--- a/src/roles/amundsen_metadata/templates/metadata_gunicorn.service.j2
+++ b/src/roles/amundsen_metadata/templates/metadata_gunicorn.service.j2
@@ -5,12 +5,12 @@ After=network.target
 [Service]
 User=amundsen
 Group=amundsen
-Environment=METADATA_SVC_CONFIG_MODULE_CLASS={{ metadata_config_class }}
-Environment=NEO4J_HOST={{ neo4j_host }}
-Environment=NEO4J_PORT={{ neo4j_port }}
-Environment=NEO4J_USER={{ neo4j_user }}
-Environment=NEO4J_PASSWORD={{ neo4j_password }}
-ExecStart={{ metadata_virtualenv }}/bin/gunicorn --workers {{ metadata_gunicorn_workers }} --bind {{ metadata_bind_host }}:{{ metadata_port }} metadata_service.metadata_wsgi:app
+Environment=METADATA_SVC_CONFIG_MODULE_CLASS={{ amundsen_metadata_config_class }}
+Environment=NEO4J_HOST={{ amundsen_metadata_neo4j_host }}
+Environment=NEO4J_PORT={{ amundsen_metadata_neo4j_port }}
+Environment=NEO4J_USER={{ amundsen_metadata_neo4j_user }}
+Environment=NEO4J_PASSWORD={{ amundsen_metadata_neo4j_password }}
+ExecStart={{ amundsen_metadata_virtualenv }}/bin/gunicorn --workers {{ amundsen_metadata_gunicorn_workers }} --bind {{ amundsen_metadata_bind_host }}:{{ amundsen_metadata_port }} metadata_service.metadata_wsgi:app
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
## Summary
- address ansible-lint warnings in Amundsen frontend/metadata roles
- update variable naming with role prefixes
- ensure boolean values use `true`
- add missing play names

## Testing
- `ansible-lint src/roles/amundsen_frontend/defaults/main.yml -p`
- `ansible-lint src/roles/amundsen_frontend/tasks/main.yml -p`
- `ansible-lint src/roles/amundsen_frontend/templates/frontend_gunicorn.service.j2 -p`
- `ansible-lint src/roles/amundsen_frontend/templates/frontend_config.py.j2 -p`
- `ansible-lint src/roles/amundsen_metadata/tasks/main.yml -p`
- `ansible-lint src/roles/amundsen_metadata/defaults/main.yml -p`
- `ansible-lint src/roles/amundsen_metadata/templates/metadata_config.py.j2 -p`
- `ansible-lint src/roles/amundsen_metadata/templates/metadata_gunicorn.service.j2 -p`
- `ansible-lint src/playbooks/site.yml -p` *(fails: openldap roles)*

------
https://chatgpt.com/codex/tasks/task_e_683dca723468832aa0d1771d527bce04