### PR TITLE
Fix variable naming in spark role

### DIFF
--- a/src/roles/spark_role/defaults/main.yml
+++ b/src/roles/spark_role/defaults/main.yml
@@ -1,30 +1,30 @@
 ---
-spark_version: "3.4.1"
-spark_hadoop_version: "3"
-spark_package_name: "spark-{{ spark_version }}-bin-hadoop{{ spark_hadoop_version }}"
-spark_download_url: "https://dlcdn.apache.org/spark/spark-{{ spark_version }}/{{ spark_package_name }}.tgz"
+spark_role_version: "3.4.1"
+spark_role_hadoop_version: "3"
+spark_role_package_name: "spark-{{ spark_role_version }}-bin-hadoop{{ spark_role_hadoop_version }}"
+spark_role_download_url: "https://dlcdn.apache.org/spark/spark-{{ spark_role_version }}/{{ spark_role_package_name }}.tgz"
 
-spark_install_dir: "/opt/spark"
-spark_symlink_dir: "{{ spark_install_dir }}/current"
+spark_role_install_dir: "/opt/spark"
+spark_role_symlink_dir: "{{ spark_role_install_dir }}/current"
 
-spark_user: "spark"
-spark_group: "{{ spark_user }}"
+spark_role_user: "spark"
+spark_role_group: "{{ spark_role_user }}"
 
-java_package: "openjdk-17-jdk"
+spark_role_java_package: "openjdk-17-jdk"
 
-spark_eventlog_dir: "/var/spark-events"
-spark_log_dir: "/var/log/spark"
-spark_worker_dir: "/var/lib/spark/work"
-spark_recovery_dir: ""
+spark_role_eventlog_dir: "/var/spark-events"
+spark_role_log_dir: "/var/log/spark"
+spark_role_worker_dir: "/var/lib/spark/work"
+spark_role_recovery_dir: ""
 
-spark_master_host: "{{ inventory_hostname }}"
-spark_master_url: "spark://{{ spark_master_host }}:7077"
+spark_role_master_host: "{{ inventory_hostname }}"
+spark_role_master_url: "spark://{{ spark_role_master_host }}:7077"
 
-spark_ha_enabled: false
-spark_zookeeper_hosts: ""
-spark_ha_zk_dir: "/spark-cluster"
+spark_role_ha_enabled: false
+spark_role_zookeeper_hosts: ""
+spark_role_ha_zk_dir: "/spark-cluster"
 
-spark_history_enabled: false
+spark_role_history_enabled: false
 
-spark_worker_memory: "1g"
-spark_worker_cores: 1
+spark_role_worker_memory: "1g"
+spark_role_worker_cores: 1

--- a/src/roles/spark_role/tasks/config.yml
+++ b/src/roles/spark_role/tasks/config.yml
@@ -2,9 +2,9 @@
 - name: Deploy spark-env.sh
   ansible.builtin.template:
     src: spark-env.sh.j2
-    dest: "{{ spark_symlink_dir }}/conf/spark-env.sh"
-    owner: "{{ spark_user }}"
-    group: "{{ spark_group }}"
+    dest: "{{ spark_role_symlink_dir }}/conf/spark-env.sh"
+    owner: "{{ spark_role_user }}"
+    group: "{{ spark_role_group }}"
     mode: "0644"
   notify:
     - Restart Spark Master
@@ -14,9 +14,9 @@
 - name: Deploy spark-defaults.conf
   ansible.builtin.template:
     src: spark-defaults.conf.j2
-    dest: "{{ spark_symlink_dir }}/conf/spark-defaults.conf"
-    owner: "{{ spark_user }}"
-    group: "{{ spark_group }}"
+    dest: "{{ spark_role_symlink_dir }}/conf/spark-defaults.conf"
+    owner: "{{ spark_role_user }}"
+    group: "{{ spark_role_group }}"
     mode: "0644"
   notify:
     - Restart Spark Master
@@ -26,9 +26,9 @@
 - name: Deploy workers file
   ansible.builtin.template:
     src: workers.j2
-    dest: "{{ spark_symlink_dir }}/conf/workers"
-    owner: "{{ spark_user }}"
-    group: "{{ spark_group }}"
+    dest: "{{ spark_role_symlink_dir }}/conf/workers"
+    owner: "{{ spark_role_user }}"
+    group: "{{ spark_role_group }}"
     mode: "0644"
   when: groups['spark_worker'] is defined
   become: true

--- a/src/roles/spark_role/tasks/install.yml
+++ b/src/roles/spark_role/tasks/install.yml
@@ -1,14 +1,14 @@
 ---
 - name: Ensure spark group exists
   ansible.builtin.group:
-    name: "{{ spark_group }}"
+    name: "{{ spark_role_group }}"
     state: present
   become: true
 
 - name: Ensure spark user exists
   ansible.builtin.user:
-    name: "{{ spark_user }}"
-    group: "{{ spark_group }}"
+    name: "{{ spark_role_user }}"
+    group: "{{ spark_role_group }}"
     create_home: true
     shell: /bin/bash
     state: present
@@ -16,40 +16,40 @@
 
 - name: Install Java
   ansible.builtin.apt:
-    name: "{{ java_package }}"
+    name: "{{ spark_role_java_package }}"
     state: present
     update_cache: true
   become: true
 
 - name: Create installation directory
   ansible.builtin.file:
-    path: "{{ spark_install_dir }}"
+    path: "{{ spark_role_install_dir }}"
     state: directory
-    owner: "{{ spark_user }}"
-    group: "{{ spark_group }}"
+    owner: "{{ spark_role_user }}"
+    group: "{{ spark_role_group }}"
     mode: "0755"
   become: true
 
 - name: Download Spark archive
   ansible.builtin.get_url:
-    url: "{{ spark_download_url }}"
-    dest: "{{ spark_install_dir }}/{{ spark_package_name }}.tgz"
+    url: "{{ spark_role_download_url }}"
+    dest: "{{ spark_role_install_dir }}/{{ spark_role_package_name }}.tgz"
     mode: "0644"
     force: false
   become: true
 
 - name: Extract Spark archive
   ansible.builtin.unarchive:
-    src: "{{ spark_install_dir }}/{{ spark_package_name }}.tgz"
-    dest: "{{ spark_install_dir }}"
+    src: "{{ spark_role_install_dir }}/{{ spark_role_package_name }}.tgz"
+    dest: "{{ spark_role_install_dir }}"
     remote_src: true
-    creates: "{{ spark_install_dir }}/{{ spark_package_name }}/bin/spark-submit"
+    creates: "{{ spark_role_install_dir }}/{{ spark_role_package_name }}/bin/spark-submit"
   become: true
 
 - name: Update Spark symlink
   ansible.builtin.file:
-    src: "{{ spark_install_dir }}/{{ spark_package_name }}"
-    dest: "{{ spark_symlink_dir }}"
+    src: "{{ spark_role_install_dir }}/{{ spark_role_package_name }}"
+    dest: "{{ spark_role_symlink_dir }}"
     state: link
     force: true
   become: true
@@ -58,13 +58,13 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    owner: "{{ spark_user }}"
-    group: "{{ spark_group }}"
+    owner: "{{ spark_role_user }}"
+    group: "{{ spark_role_group }}"
     mode: "0755"
   loop:
-    - "{{ spark_eventlog_dir }}"
-    - "{{ spark_log_dir }}"
-    - "{{ spark_worker_dir }}"
-    - "{{ spark_recovery_dir | default(omit) }}"
+    - "{{ spark_role_eventlog_dir }}"
+    - "{{ spark_role_log_dir }}"
+    - "{{ spark_role_worker_dir }}"
+    - "{{ spark_role_recovery_dir | default(omit) }}"
   when: item is not none
   become: true

--- a/src/roles/spark_role/tasks/service.yml
+++ b/src/roles/spark_role/tasks/service.yml
@@ -22,7 +22,7 @@
     src: spark-history-server.service.j2
     dest: /etc/systemd/system/spark-history-server.service
     mode: "0644"
-  when: spark_history_enabled | bool and inventory_hostname in groups['spark_master']
+  when: spark_role_history_enabled | bool and inventory_hostname in groups['spark_master']
   notify: Restart Spark History Server
   become: true
 
@@ -52,5 +52,5 @@
     name: spark-history-server
     state: started
     enabled: true
-  when: spark_history_enabled | bool and inventory_hostname in groups['spark_master']
+  when: spark_role_history_enabled | bool and inventory_hostname in groups['spark_master']
   become: true

--- a/src/roles/spark_role/templates/spark-defaults.conf.j2
+++ b/src/roles/spark_role/templates/spark-defaults.conf.j2
@@ -1,6 +1,6 @@
 spark.eventLog.enabled                 true
-spark.eventLog.dir                     {{ spark_eventlog_dir }}
-spark.history.fs.logDirectory          {{ spark_eventlog_dir }}
-{% if spark_history_enabled | bool %}
+spark.eventLog.dir                     {{ spark_role_eventlog_dir }}
+spark.history.fs.logDirectory          {{ spark_role_eventlog_dir }}
+{% if spark_role_history_enabled | bool %}
 spark.history.ui.port                  18080
 {% endif %}

--- a/src/roles/spark_role/templates/spark-env.sh.j2
+++ b/src/roles/spark_role/templates/spark-env.sh.j2
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-export SPARK_MASTER_HOST="{{ spark_master_host }}"
+export SPARK_MASTER_HOST="{{ spark_role_master_host }}"
 export JAVA_HOME="{{ lookup('env', 'JAVA_HOME') | default('/usr/lib/jvm/default-java', true) }}"
-export SPARK_LOG_DIR="{{ spark_log_dir }}"
-export SPARK_WORKER_DIR="{{ spark_worker_dir }}"
-export SPARK_WORKER_MEMORY="{{ spark_worker_memory }}"
-export SPARK_WORKER_CORES="{{ spark_worker_cores }}"
+export SPARK_LOG_DIR="{{ spark_role_log_dir }}"
+export SPARK_WORKER_DIR="{{ spark_role_worker_dir }}"
+export SPARK_WORKER_MEMORY="{{ spark_role_worker_memory }}"
+export SPARK_WORKER_CORES="{{ spark_role_worker_cores }}"
 
-{% if spark_ha_enabled | bool %}
-export SPARK_DAEMON_JAVA_OPTS="$SPARK_DAEMON_JAVA_OPTS -Dspark.deploy.recoveryMode=ZOOKEEPER -Dspark.deploy.zookeeper.url={{ spark_zookeeper_hosts }} -Dspark.deploy.zookeeper.dir={{ spark_ha_zk_dir }}"
+{% if spark_role_ha_enabled | bool %}
+export SPARK_DAEMON_JAVA_OPTS="$SPARK_DAEMON_JAVA_OPTS -Dspark.deploy.recoveryMode=ZOOKEEPER -Dspark.deploy.zookeeper.url={{ spark_role_zookeeper_hosts }} -Dspark.deploy.zookeeper.dir={{ spark_role_ha_zk_dir }}"
 {% endif %}
 
-{% if spark_recovery_dir | length > 0 and not spark_ha_enabled | bool %}
-export SPARK_DAEMON_JAVA_OPTS="$SPARK_DAEMON_JAVA_OPTS -Dspark.deploy.recoveryMode=FILESYSTEM -Dspark.deploy.recoveryDirectory={{ spark_recovery_dir }}"
+{% if spark_role_recovery_dir | length > 0 and not spark_role_ha_enabled | bool %}
+export SPARK_DAEMON_JAVA_OPTS="$SPARK_DAEMON_JAVA_OPTS -Dspark.deploy.recoveryMode=FILESYSTEM -Dspark.deploy.recoveryDirectory={{ spark_role_recovery_dir }}"
 {% endif %}

--- a/src/roles/spark_role/templates/spark-history-server.service.j2
+++ b/src/roles/spark_role/templates/spark-history-server.service.j2
@@ -5,11 +5,11 @@ Wants=network-online.target
 
 [Service]
 Type=forking
-User={{ spark_user }}
-Group={{ spark_group }}
-WorkingDirectory={{ spark_symlink_dir }}/sbin
-ExecStart={{ spark_symlink_dir }}/sbin/start-history-server.sh
-ExecStop={{ spark_symlink_dir }}/sbin/stop-history-server.sh
+User={{ spark_role_user }}
+Group={{ spark_role_group }}
+WorkingDirectory={{ spark_role_symlink_dir }}/sbin
+ExecStart={{ spark_role_symlink_dir }}/sbin/start-history-server.sh
+ExecStop={{ spark_role_symlink_dir }}/sbin/stop-history-server.sh
 SuccessExitStatus=143
 Restart=on-failure
 

--- a/src/roles/spark_role/templates/spark-master.service.j2
+++ b/src/roles/spark_role/templates/spark-master.service.j2
@@ -5,11 +5,11 @@ Wants=network-online.target
 
 [Service]
 Type=forking
-User={{ spark_user }}
-Group={{ spark_group }}
-WorkingDirectory={{ spark_symlink_dir }}/sbin
-ExecStart={{ spark_symlink_dir }}/sbin/start-master.sh
-ExecStop={{ spark_symlink_dir }}/sbin/stop-master.sh
+User={{ spark_role_user }}
+Group={{ spark_role_group }}
+WorkingDirectory={{ spark_role_symlink_dir }}/sbin
+ExecStart={{ spark_role_symlink_dir }}/sbin/start-master.sh
+ExecStop={{ spark_role_symlink_dir }}/sbin/stop-master.sh
 SuccessExitStatus=143
 Restart=on-failure
 

--- a/src/roles/spark_role/templates/spark-worker.service.j2
+++ b/src/roles/spark_role/templates/spark-worker.service.j2
@@ -5,11 +5,11 @@ Wants=network-online.target
 
 [Service]
 Type=forking
-User={{ spark_user }}
-Group={{ spark_group }}
-WorkingDirectory={{ spark_symlink_dir }}/sbin
-ExecStart={{ spark_symlink_dir }}/sbin/start-worker.sh {{ spark_master_url }}
-ExecStop={{ spark_symlink_dir }}/sbin/stop-worker.sh
+User={{ spark_role_user }}
+Group={{ spark_role_group }}
+WorkingDirectory={{ spark_role_symlink_dir }}/sbin
+ExecStart={{ spark_role_symlink_dir }}/sbin/start-worker.sh {{ spark_role_master_url }}
+ExecStop={{ spark_role_symlink_dir }}/sbin/stop-worker.sh
 SuccessExitStatus=143
 Restart=on-failure
 


### PR DESCRIPTION
## Summary
- fix var-naming warnings in the spark_role by prefixing variables with `spark_role_`
- update tasks and templates to use new variables

## Testing
- `ansible-lint src/roles/spark_role`
- `ansible-lint`

------
https://chatgpt.com/codex/tasks/task_e_683ddea87808832a8563c41d0deaf2d7