### PR TITLE
Fix ansible-lint warnings

### DIFF
--- a/src/roles/apache_airflow/tasks/config.yml
+++ b/src/roles/apache_airflow/tasks/config.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create Airflow home and subdirs
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     owner: "{{ airflow_user }}"
@@ -12,7 +12,7 @@
     - "{{ airflow_home }}/logs"
 
 - name: Deploy airflow.cfg
-  template:
+  ansible.builtin.template:
     src: airflow.cfg.j2
     dest: "{{ airflow_home }}/airflow.cfg"
     owner: "{{ airflow_user }}"
@@ -24,7 +24,7 @@
     - restart airflow-worker
 
 - name: Deploy environment file for systemd
-  template:
+  ansible.builtin.template:
     src: airflow.env.j2
     dest: /etc/default/airflow
     owner: root

--- a/src/roles/apache_airflow/tasks/main.yml
+++ b/src/roles/apache_airflow/tasks/main.yml
@@ -1,6 +1,15 @@
 ---
-- import_tasks: users.yml
-- import_tasks: install.yml
-- import_tasks: pip.yml
-- import_tasks: config.yml
-- import_tasks: service.yml
+- name: Create airflow users
+  ansible.builtin.import_tasks: users.yml
+
+- name: Install airflow
+  ansible.builtin.import_tasks: install.yml
+
+- name: Install Python packages
+  ansible.builtin.import_tasks: pip.yml
+
+- name: Configure airflow
+  ansible.builtin.import_tasks: config.yml
+
+- name: Manage service
+  ansible.builtin.import_tasks: service.yml

--- a/src/roles/apache_airflow/tasks/users.yml
+++ b/src/roles/apache_airflow/tasks/users.yml
@@ -1,11 +1,11 @@
 ---
 - name: Ensure airflow group exists
-  group:
+  ansible.builtin.group:
     name: "{{ airflow_group }}"
     state: present
 
 - name: Ensure airflow user exists
-  user:
+  ansible.builtin.user:
     name: "{{ airflow_user }}"
     group: "{{ airflow_group }}"
     home: "{{ airflow_home }}"

--- a/src/roles/openldap_server/handlers/main.yml
+++ b/src/roles/openldap_server/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart slapd
+- name: Restart slapd
   ansible.builtin.service:
     name: slapd
     state: restarted

--- a/src/roles/openldap_server/tasks/config.yml
+++ b/src/roles/openldap_server/tasks/config.yml
@@ -2,10 +2,10 @@
 - name: Set log level
   community.general.ldap_attrs:
     dn: "cn=config"
-    attribute: olcLogLevel
-    values: "{{ ldap_log_level }}"
+    attributes:
+      olcLogLevel: "{{ ldap_log_level }}"
     state: present
-    bind_url: "ldapi:///"
+    server_uri: "ldapi:///"
   notify: restart slapd
 
 - name: Configure TLS (if enabled)

--- a/src/roles/openldap_server/tasks/install.yml
+++ b/src/roles/openldap_server/tasks/install.yml
@@ -13,7 +13,9 @@
 
 - name: Install OpenLDAP server packages
   ansible.builtin.apt:
-    name: [ slapd, ldap-utils ]
+    name:
+      - slapd
+      - ldap-utils
     state: present
     update_cache: true
 

--- a/src/roles/openldap_server/tasks/main.yml
+++ b/src/roles/openldap_server/tasks/main.yml
@@ -1,3 +1,6 @@
 ---
-- ansible.builtin.import_tasks: install.yml
-- ansible.builtin.import_tasks: config.yml
+- name: Install OpenLDAP packages
+  ansible.builtin.import_tasks: install.yml
+
+- name: Configure OpenLDAP
+  ansible.builtin.import_tasks: config.yml

--- a/src/roles/openldap_server/tasks/tls.yml
+++ b/src/roles/openldap_server/tasks/tls.yml
@@ -31,5 +31,5 @@
       olcTLSCertificateKeyFile: "/etc/ldap/ssl/ldap.key"
       olcTLSCACertificateFile: "/etc/ldap/ssl/ca.crt"
     state: present
-    bind_url: "ldapi:///"
+    server_uri: "ldapi:///"
   notify: restart slapd

--- a/src/roles/postgres_backup/tasks/main.yml
+++ b/src/roles/postgres_backup/tasks/main.yml
@@ -4,22 +4,27 @@
   ansible.builtin.file:
     path: "{{ backup_dir }}"
     state: directory
+    owner: root
+    group: root
+    mode: "0755"
 
 - name: Deploy backup script
   ansible.builtin.template:
     src: backup_postgres.sh.j2
     dest: /usr/local/bin/backup_postgres.sh
-    mode: 0755
+    mode: "0755"
 
 - name: Deploy systemd service
   ansible.builtin.template:
     src: postgres_backup.service.j2
     dest: /etc/systemd/system/postgres_backup.service
+    mode: "0644"
 
 - name: Deploy systemd timer
   ansible.builtin.template:
     src: postgres_backup.timer.j2
     dest: /etc/systemd/system/postgres_backup.timer
+    mode: "0644"
 
 - name: Reload systemd
   ansible.builtin.systemd:

--- a/src/roles/postgresql/defaults/main.yml
+++ b/src/roles/postgresql/defaults/main.yml
@@ -3,7 +3,9 @@
 # Version & repository
 postgresql_version: 15
 postgresql_use_official_repo: false
-postgresql_apt_repo_url: "deb [signed-by=/usr/share/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main"
+postgresql_apt_repo_url: >-
+  deb [signed-by=/usr/share/keyrings/postgresql.gpg]
+  http://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main
 postgresql_apt_repo_key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
 
 # Environment
@@ -21,17 +23,17 @@ postgresql_shared_buffers: "{{ '1GB' if postgresql_env == 'prod' else '256MB' }}
 postgresql_work_mem: 4MB
 postgresql_maintenance_work_mem: 64MB
 postgresql_effective_cache_size: "{{ '3GB' if postgresql_env == 'prod' else '768MB' }}"
-postgresql_logging_collector: on
+postgresql_logging_collector: true
 postgresql_log_directory: 'log'
 postgresql_log_min_duration_statement: -1
 postgresql_password_encryption: scram-sha-256
 
 # Authentication
 postgresql_hba_entries:
-  - { type: 'local', database: 'all', user: 'postgres', address: '',   auth_method: 'peer' }
-  - { type: 'local', database: 'all', user: 'all',      address: '',   auth_method: 'peer' }
-  - { type: 'host',  database: 'all', user: 'all',      address: '127.0.0.1/32', auth_method: 'md5' }
-  - { type: 'host',  database: 'all', user: 'all',      address: '::1/128',      auth_method: 'md5' }
+  - { type: 'local', database: 'all', user: 'postgres', address: '', auth_method: 'peer' }
+  - { type: 'local', database: 'all', user: 'all', address: '', auth_method: 'peer' }
+  - { type: 'host', database: 'all', user: 'all', address: '127.0.0.1/32', auth_method: 'md5' }
+  - { type: 'host', database: 'all', user: 'all', address: '::1/128', auth_method: 'md5' }
 
 # Admin & replication
 postgresql_admin_password: ""
@@ -43,9 +45,9 @@ postgresql_replication_network: ""
 
 # HA / Patroni
 postgresql_use_patroni: false
-patroni_etcd_host: ""
-patroni_cluster_name: pg-cluster
-patroni_node_name: "{{ inventory_hostname }}"
+postgresql_patroni_etcd_host: ""
+postgresql_patroni_cluster_name: pg-cluster
+postgresql_patroni_node_name: "{{ inventory_hostname }}"
 
 # SSL
 postgresql_enable_ssl: false
@@ -56,4 +58,3 @@ postgresql_ssl_key_file: ""
 postgresql_configure_firewall: false
 postgresql_firewall_use_ufw: true
 postgresql_allowed_hosts: []
-

--- a/src/roles/postgresql/tasks/replication.yml
+++ b/src/roles/postgresql/tasks/replication.yml
@@ -16,7 +16,15 @@
   ansible.builtin.lineinfile:
     path: "{{ postgresql_data_dir }}/postgresql.auto.conf"
     regexp: '^primary_conninfo ='
-    line: "primary_conninfo = '{{ postgresql_primary_conninfo | default('host=' ~ groups['postgres_primary'][0] ~ ' user=' ~ postgresql_replication_user ~ ' password=' ~ postgresql_replication_password) }}'"
+    line: >-
+      primary_conninfo = '{{
+        postgresql_primary_conninfo |
+        default(
+          'host=' ~ groups['postgres_primary'][0] ~
+          ' user=' ~ postgresql_replication_user ~
+          ' password=' ~ postgresql_replication_password
+        )
+      }}'
     owner: postgres
     group: postgres
     mode: '0600'

--- a/src/roles/postgresql/templates/patroni.yml.j2
+++ b/src/roles/postgresql/templates/patroni.yml.j2
@@ -1,8 +1,8 @@
-scope: {{ patroni_cluster_name }}
-name: {{ patroni_node_name }}
+scope: {{ postgresql_patroni_cluster_name }}
+name: {{ postgresql_patroni_node_name }}
 
 etcd:
-  hosts: {{ patroni_etcd_host }}
+  hosts: {{ postgresql_patroni_etcd_host }}
 
 restapi:
   listen: 127.0.0.1:8008


### PR DESCRIPTION
## Summary
- clean up openldap role lint warnings
- fix postgres backup permissions
- update postgresql defaults
- tweak airflow tasks for FQCN

## Testing
- `ansible-lint src/roles/apache_airflow/tasks/main.yml src/roles/apache_airflow/tasks/config.yml src/roles/apache_airflow/tasks/users.yml src/roles/openldap_server/tasks/main.yml src/roles/openldap_server/tasks/install.yml src/roles/openldap_server/tasks/config.yml src/roles/openldap_server/tasks/tls.yml src/roles/openldap_server/handlers/main.yml src/roles/postgres_backup/tasks/main.yml src/roles/postgresql/tasks/replication.yml src/roles/postgresql/defaults/main.yml src/roles/postgresql/templates/patroni.yml.j2`

------
https://chatgpt.com/codex/tasks/task_e_683deb41abb8832a8edcdd0e84ebec80