### PR TITLE
Fix some ansible lint issues

### DIFF
--- a/src/roles/apache_airflow/defaults/main.yml
+++ b/src/roles/apache_airflow/defaults/main.yml
@@ -1,24 +1,24 @@
 ---
-airflow_version: "2.6.3"
+apache_airflow_version: "2.6.3"
 
-airflow_user: "airflow"
-airflow_group: "airflow"
-airflow_home: "/opt/airflow"
-airflow_python: "/usr/bin/python3"           # Change if using a venv
-airflow_venv_path: ""                        # e.g. /opt/airflow/venv (leave blank for system python)
+apache_airflow_user: "airflow"
+apache_airflow_group: "airflow"
+apache_airflow_home: "/opt/airflow"
+apache_airflow_python: "/usr/bin/python3"           # Change if using a venv
+apache_airflow_venv_path: ""                        # e.g. /opt/airflow/venv (leave blank for system python)
 
-airflow_executor: "SequentialExecutor"       # Override to CeleryExecutor for multi-node
-airflow_systemd_units_enabled:
+apache_airflow_executor: "SequentialExecutor"       # Override to CeleryExecutor for multi-node
+apache_airflow_systemd_units_enabled:
   - webserver
   - scheduler
   - worker                                    # Ignored if not CeleryExecutor
 
-airflow_database_url: "sqlite:///{{ airflow_home }}/airflow.db"
-airflow_broker_url: "redis://localhost:6379/0"      # Only for CeleryExecutor
+apache_airflow_database_url: "sqlite:///{{ apache_airflow_home }}/airflow.db"
+apache_airflow_broker_url: "redis://localhost:6379/0"      # Only for CeleryExecutor
 
-airflow_fernet_key: "CHANGE_ME"                      # Vault this in production
-airflow_remote_logging: false
-airflow_elasticsearch_host: "http://elasticsearch:9200"
-airflow_logging_json: true
+apache_airflow_fernet_key: "CHANGE_ME"                      # Vault this in production
+apache_airflow_remote_logging: false
+apache_airflow_elasticsearch_host: "http://elasticsearch:9200"
+apache_airflow_logging_json: true
 
-airflow_extra_pip_packages: []               # e.g. ['apache-airflow[celery,redis]']
+apache_airflow_extra_pip_packages: []               # e.g. ['apache-airflow[celery,redis]']

--- a/src/roles/apache_airflow/handlers/main.yml
+++ b/src/roles/apache_airflow/handlers/main.yml
@@ -1,21 +1,21 @@
 ---
-- name: reload systemd
+- name: Reload systemd
   ansible.builtin.systemd:
     daemon_reload: true
 
-- name: restart airflow-webserver
+- name: Restart airflow-webserver
   ansible.builtin.service:
     name: airflow-webserver
     state: restarted
     enabled: true
 
-- name: restart airflow-scheduler
+- name: Restart airflow-scheduler
   ansible.builtin.service:
     name: airflow-scheduler
     state: restarted
     enabled: true
 
-- name: restart airflow-worker
+- name: Restart airflow-worker
   ansible.builtin.service:
     name: airflow-worker
     state: restarted

--- a/src/roles/apache_airflow/molecule/default/converge.yml
+++ b/src/roles/apache_airflow/molecule/default/converge.yml
@@ -3,5 +3,5 @@
   hosts: all
   become: true
   roles:
-    - role: ../../
-      airflow_executor: "SequentialExecutor"
+    - role: apache_airflow
+      apache_airflow_executor: "SequentialExecutor"

--- a/src/roles/apache_airflow/molecule/default/tests/test_airflow.py
+++ b/src/roles/apache_airflow/molecule/default/tests/test_airflow.py
@@ -1,5 +1,5 @@
 import testinfra.utils.ansible_runner
 
-def test_airflow_cli(host):
+def test_apache_airflow_cli(host):
     cmd = host.run("airflow version")
     assert cmd.rc == 0

--- a/src/roles/apache_airflow/tasks/config.yml
+++ b/src/roles/apache_airflow/tasks/config.yml
@@ -3,20 +3,20 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    owner: "{{ airflow_user }}"
-    group: "{{ airflow_group }}"
+    owner: "{{ apache_airflow_user }}"
+    group: "{{ apache_airflow_group }}"
     mode: "0755"
   loop:
-    - "{{ airflow_home }}"
-    - "{{ airflow_home }}/dags"
-    - "{{ airflow_home }}/logs"
+    - "{{ apache_airflow_home }}"
+    - "{{ apache_airflow_home }}/dags"
+    - "{{ apache_airflow_home }}/logs"
 
 - name: Deploy airflow.cfg
   ansible.builtin.template:
     src: airflow.cfg.j2
-    dest: "{{ airflow_home }}/airflow.cfg"
-    owner: "{{ airflow_user }}"
-    group: "{{ airflow_group }}"
+    dest: "{{ apache_airflow_home }}/airflow.cfg"
+    owner: "{{ apache_airflow_user }}"
+    group: "{{ apache_airflow_group }}"
     mode: "0600"
   notify:
     - restart airflow-webserver

--- a/src/roles/apache_airflow/tasks/pip.yml
+++ b/src/roles/apache_airflow/tasks/pip.yml
@@ -1,28 +1,28 @@
 ---
 - name: Optionally create venv
-  ansible.builtin.command: "{{ airflow_python }} -m venv {{ airflow_venv_path }}"
+  ansible.builtin.command: "{{ apache_airflow_python }} -m venv {{ apache_airflow_venv_path }}"
   args:
-    creates: "{{ airflow_venv_path }}/bin/activate"
-  when: airflow_venv_path | length > 0
+    creates: "{{ apache_airflow_venv_path }}/bin/activate"
+  when: apache_airflow_venv_path | length > 0
 
 - name: Install/upgrade pip in venv or system
   ansible.builtin.pip:
     name: pip
     state: present
-    virtualenv: "{{ airflow_venv_path | default(omit) }}"
-    virtualenv_command: "{{ airflow_python }} -m venv"
-    virtualenv_python: "{{ airflow_python }}"
+    virtualenv: "{{ apache_airflow_venv_path | default(omit) }}"
+    virtualenv_command: "{{ apache_airflow_python }} -m venv"
+    virtualenv_python: "{{ apache_airflow_python }}"
 
 - name: Install Apache Airflow
   ansible.builtin.pip:
-    name: "apache-airflow=={{ airflow_version }}"
-    extra_args: "-r https://raw.githubusercontent.com/apache/airflow/constraints-{{ airflow_version }}/constraints-3.10.txt"
-    virtualenv: "{{ airflow_venv_path | default(omit) }}"
+    name: "apache-airflow=={{ apache_airflow_version }}"
+    extra_args: "-r https://raw.githubusercontent.com/apache/airflow/constraints-{{ apache_airflow_version }}/constraints-3.10.txt"
+    virtualenv: "{{ apache_airflow_venv_path | default(omit) }}"
     virtualenv_site_packages: false
 
 - name: Install extra Airflow packages
   ansible.builtin.pip:
-    name: "{{ airflow_extra_pip_packages }}"
+    name: "{{ apache_airflow_extra_pip_packages }}"
     state: present
-    virtualenv: "{{ airflow_venv_path | default(omit) }}"
-  when: airflow_extra_pip_packages | length > 0
+    virtualenv: "{{ apache_airflow_venv_path | default(omit) }}"
+  when: apache_airflow_extra_pip_packages | length > 0

--- a/src/roles/apache_airflow/tasks/service.yml
+++ b/src/roles/apache_airflow/tasks/service.yml
@@ -7,7 +7,7 @@
     group: root
     mode: "0644"
   loop:
-    - "{{ airflow_systemd_units_enabled }}"
+    - "{{ apache_airflow_systemd_units_enabled }}"
   notify:
     - reload systemd
 
@@ -16,4 +16,4 @@
     name: "airflow-{{ item }}.service"
     enabled: true
     state: started
-  loop: "{{ airflow_systemd_units_enabled }}"
+  loop: "{{ apache_airflow_systemd_units_enabled }}"

--- a/src/roles/apache_airflow/tasks/users.yml
+++ b/src/roles/apache_airflow/tasks/users.yml
@@ -1,14 +1,14 @@
 ---
 - name: Ensure airflow group exists
   ansible.builtin.group:
-    name: "{{ airflow_group }}"
+    name: "{{ apache_airflow_group }}"
     state: present
 
 - name: Ensure airflow user exists
   ansible.builtin.user:
-    name: "{{ airflow_user }}"
-    group: "{{ airflow_group }}"
-    home: "{{ airflow_home }}"
+    name: "{{ apache_airflow_user }}"
+    group: "{{ apache_airflow_group }}"
+    home: "{{ apache_airflow_home }}"
     create_home: true
     shell: /usr/sbin/nologin
     system: true

--- a/src/roles/apache_airflow/templates/airflow-scheduler.service.j2
+++ b/src/roles/apache_airflow/templates/airflow-scheduler.service.j2
@@ -5,10 +5,10 @@ Wants=network.target
 
 [Service]
 EnvironmentFile=/etc/default/airflow
-User={{ airflow_user }}
-Group={{ airflow_group }}
+User={{ apache_airflow_user }}
+Group={{ apache_airflow_group }}
 Type=simple
-ExecStart={{ airflow_venv_path | default('') }}/bin/airflow scheduler
+ExecStart={{ apache_airflow_venv_path | default('') }}/bin/airflow scheduler
 Restart=on-failure
 RestartSec=5
 

--- a/src/roles/apache_airflow/templates/airflow-webserver.service.j2
+++ b/src/roles/apache_airflow/templates/airflow-webserver.service.j2
@@ -5,10 +5,10 @@ Wants=network.target
 
 [Service]
 EnvironmentFile=/etc/default/airflow
-User={{ airflow_user }}
-Group={{ airflow_group }}
+User={{ apache_airflow_user }}
+Group={{ apache_airflow_group }}
 Type=simple
-ExecStart={{ airflow_venv_path | default('') }}/bin/airflow webserver --port 8080
+ExecStart={{ apache_airflow_venv_path | default('') }}/bin/airflow webserver --port 8080
 Restart=on-failure
 RestartSec=5
 

--- a/src/roles/apache_airflow/templates/airflow-worker.service.j2
+++ b/src/roles/apache_airflow/templates/airflow-worker.service.j2
@@ -6,10 +6,10 @@ Wants=network.target redis-server.service
 
 [Service]
 EnvironmentFile=/etc/default/airflow
-User={{ airflow_user }}
-Group={{ airflow_group }}
+User={{ apache_airflow_user }}
+Group={{ apache_airflow_group }}
 Type=simple
-ExecStart={{ airflow_venv_path | default('') }}/bin/airflow celery worker
+ExecStart={{ apache_airflow_venv_path | default('') }}/bin/airflow celery worker
 Restart=always
 RestartSec=5
 

--- a/src/roles/apache_airflow/templates/airflow.cfg.j2
+++ b/src/roles/apache_airflow/templates/airflow.cfg.j2
@@ -1,26 +1,26 @@
 [core]
-executor = {{ airflow_executor }}
-sql_alchemy_conn = {{ airflow_database_url }}
-fernet_key = {{ airflow_fernet_key }}
-dags_folder = {{ airflow_home }}/dags
-base_log_folder = {{ airflow_home }}/logs
+executor = {{ apache_airflow_executor }}
+sql_alchemy_conn = {{ apache_airflow_database_url }}
+fernet_key = {{ apache_airflow_fernet_key }}
+dags_folder = {{ apache_airflow_home }}/dags
+base_log_folder = {{ apache_airflow_home }}/logs
 load_examples = False
 
-{% if airflow_executor == 'CeleryExecutor' %}
+{% if apache_airflow_executor == 'CeleryExecutor' %}
 [celery]
-broker_url = {{ airflow_broker_url }}
-result_backend = db+{{ airflow_database_url }}
+broker_url = {{ apache_airflow_broker_url }}
+result_backend = db+{{ apache_airflow_database_url }}
 {% endif %}
 
 [logging]
-remote_logging = {{ airflow_remote_logging | bool | ternary('True', 'False') }}
+remote_logging = {{ apache_airflow_remote_logging | bool | ternary('True', 'False') }}
 logging_level = INFO
-json_format = {{ airflow_logging_json | bool | ternary('True', 'False') }}
+json_format = {{ apache_airflow_logging_json | bool | ternary('True', 'False') }}
 log_filename_template = {{ '{{ dag_id }}/{{ task_id }}/{{ execution_date }}/{{ try_number }}.log' }}
 
-{% if airflow_remote_logging %}
+{% if apache_airflow_remote_logging %}
 [elasticsearch]
-host = {{ airflow_elasticsearch_host }}
+host = {{ apache_airflow_elasticsearch_host }}
 log_id_template = {{ '{{ dag_id }}-{{ task_id }}-{{ execution_date }}-{{ try_number }}' }}
-json_format = {{ airflow_logging_json | bool | ternary('True', 'False') }}
+json_format = {{ apache_airflow_logging_json | bool | ternary('True', 'False') }}
 {% endif %}

--- a/src/roles/apache_airflow/templates/airflow.env.j2
+++ b/src/roles/apache_airflow/templates/airflow.env.j2
@@ -1,3 +1,3 @@
-AIRFLOW_HOME={{ airflow_home }}
-AIRFLOW_CONFIG={{ airflow_home }}/airflow.cfg
-PATH={{ airflow_venv_path | default('') }}/bin:{{ ansible_env.PATH }}
+AIRFLOW_HOME={{ apache_airflow_home }}
+AIRFLOW_CONFIG={{ apache_airflow_home }}/airflow.cfg
+PATH={{ apache_airflow_venv_path | default('') }}/bin:{{ ansible_env.PATH }}

--- a/src/roles/openldap_logging/handlers/main.yml
+++ b/src/roles/openldap_logging/handlers/main.yml
@@ -1,9 +1,9 @@
 ---
-- name: restart rsyslog
+- name: Restart rsyslog
   ansible.builtin.service:
     name: rsyslog
     state: restarted
-- name: restart filebeat
+- name: Restart filebeat
   ansible.builtin.service:
     name: filebeat
     state: restarted

--- a/src/roles/openldap_logging/tasks/main.yml
+++ b/src/roles/openldap_logging/tasks/main.yml
@@ -2,6 +2,9 @@
 - name: Configure rsyslog for ldap
   ansible.builtin.copy:
     dest: /etc/rsyslog.d/50-ldap.conf
+    owner: root
+    group: root
+    mode: "0644"
     content: |
       local4.*    /var/log/ldap.log
   notify: restart rsyslog
@@ -16,6 +19,9 @@
   ansible.builtin.template:
     src: filebeat.yml.j2
     dest: /etc/filebeat/filebeat.yml
+    owner: root
+    group: root
+    mode: "0644"
   notify: restart filebeat
 
 - name: Ensure services running

--- a/src/roles/openldap_replication/defaults/main.yml
+++ b/src/roles/openldap_replication/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-ldap_replication_provider_uri: "ldap://{{ inventory_hostname }}"
-ldap_replication_bind_dn: "cn=admin,{{ ldap_base_dn }}"
-ldap_replication_bind_pw: "{{ ldap_admin_password }}"
+openldap_replication_provider_uri: "ldap://{{ inventory_hostname }}"
+openldap_replication_bind_dn: "cn=admin,{{ ldap_base_dn }}"
+openldap_replication_bind_pw: "{{ ldap_admin_password }}"

--- a/src/roles/openldap_replication/templates/syncrepl.ldif.j2
+++ b/src/roles/openldap_replication/templates/syncrepl.ldif.j2
@@ -2,7 +2,7 @@ dn: olcDatabase={1}mdb,cn=config
 changetype: modify
 replace: olcSyncRepl
 {% for host in groups['ldap_servers'] if host != inventory_hostname %}
-olcSyncRepl: rid={{ '%03d' % loop.index }} provider=ldap://{{ host }} binddn="{{ ldap_replication_bind_dn }}" bindmethod=simple credentials={{ ldap_replication_bind_pw }} searchbase="{{ ldap_base_dn }}" type=refreshAndPersist retry="5 5 300 5" timeout=1
+olcSyncRepl: rid={{ '%03d' % loop.index }} provider=ldap://{{ host }} binddn="{{ openldap_replication_bind_dn }}" bindmethod=simple credentials={{ openldap_replication_bind_pw }} searchbase="{{ ldap_base_dn }}" type=refreshAndPersist retry="5 5 300 5" timeout=1
 {% endfor %}
 -
 add: olcMirrorMode

--- a/src/roles/prometheus/defaults/main.yml
+++ b/src/roles/prometheus/defaults/main.yml
@@ -30,6 +30,6 @@ prometheus_alert_rules: |
           labels:
             severity: critical
           annotations:
-            description: "{{ $labels.instance }} is down for more than 5 minutes."
+            description: "{% raw %}{{ $labels.instance }}{% endraw %} is down for more than 5 minutes."
 
 prometheus_rules_file: /etc/prometheus/alert.rules


### PR DESCRIPTION
## Summary
- rename variables in apache_airflow role to follow prefix requirements
- adjust handlers and tasks naming
- set file permissions in openldap_logging
- rename replication variables
- escape jinja template in prometheus defaults

## Testing
- `ansible-lint src/roles/apache_airflow`
- `ansible-lint src/roles/openldap_logging`
- `ansible-lint src/roles/openldap_replication` *(fails: args module warnings etc.)*
- `ansible-lint` *(fails: many remaining violations)*

------
https://chatgpt.com/codex/tasks/task_e_683df9f39130832aa2c6e7c7af176155