### PR TITLE
Fix multiple ansible-lint violations

### DIFF
--- a/src/roles/amundsen_search/defaults/main.yml
+++ b/src/roles/amundsen_search/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 amundsen_search_version: "4.0.0"
-search_bind_host: "0.0.0.0"
-search_port: 5001
-search_gunicorn_workers: 4
-search_virtualenv: "/opt/amundsen/search/venv"
-es_host: "localhost"
-es_port: 9200
-search_config_class: "search_service.config.ProdConfig"
+amundsen_search_bind_host: "0.0.0.0"
+amundsen_search_port: 5001
+amundsen_search_gunicorn_workers: 4
+amundsen_search_virtualenv: "/opt/amundsen/search/venv"
+amundsen_search_es_host: "localhost"
+amundsen_search_es_port: 9200
+amundsen_search_config_class: "search_service.config.ProdConfig"

--- a/src/roles/amundsen_search/tasks/main.yml
+++ b/src/roles/amundsen_search/tasks/main.yml
@@ -13,18 +13,18 @@
     group: amundsen
     mode: "0755"
   loop:
-    - "{{ search_virtualenv | dirname }}"
+    - "{{ amundsen_search_virtualenv | dirname }}"
   become: true
 
 - name: Create virtualenv for search service
-  ansible.builtin.command: python3 -m venv "{{ search_virtualenv }}"
+  ansible.builtin.command: python3 -m venv "{{ amundsen_search_virtualenv }}"
   args:
-    creates: "{{ search_virtualenv }}/bin/activate"
+    creates: "{{ amundsen_search_virtualenv }}/bin/activate"
   become: true
 
 - name: Install search service
   ansible.builtin.pip:
-    virtualenv: "{{ search_virtualenv }}"
+    virtualenv: "{{ amundsen_search_virtualenv }}"
     name: "amundsen-search=={{ amundsen_search_version }}"
     state: present
   become: true
@@ -32,7 +32,7 @@
 - name: Deploy search config
   ansible.builtin.template:
     src: search_config.py.j2
-    dest: "{{ search_virtualenv }}/config.py"
+    dest: "{{ amundsen_search_virtualenv }}/config.py"
     owner: amundsen
     group: amundsen
     mode: "0644"

--- a/src/roles/amundsen_search/templates/search_config.py.j2
+++ b/src/roles/amundsen_search/templates/search_config.py.j2
@@ -1,5 +1,5 @@
 from search_service.config_common import Config
 
 class ProdConfig(Config):
-    ELASTICSEARCH_ENDPOINT = "http://{{ es_host }}:{{ es_port }}"
+    ELASTICSEARCH_ENDPOINT = "http://{{ amundsen_search_es_host }}:{{ amundsen_search_es_port }}"
     LOG_LEVEL = "INFO"

--- a/src/roles/amundsen_search/templates/search_gunicorn.service.j2
+++ b/src/roles/amundsen_search/templates/search_gunicorn.service.j2
@@ -5,10 +5,10 @@ After=network.target
 [Service]
 User=amundsen
 Group=amundsen
-Environment=SEARCH_SVC_CONFIG_MODULE_CLASS={{ search_config_class }}
-Environment=ELASTICSEARCH_HOST={{ es_host }}
-Environment=ELASTICSEARCH_PORT={{ es_port }}
-ExecStart={{ search_virtualenv }}/bin/gunicorn --workers {{ search_gunicorn_workers }} --bind {{ search_bind_host }}:{{ search_port }} search_service.search_wsgi:app
+Environment=SEARCH_SVC_CONFIG_MODULE_CLASS={{ amundsen_search_config_class }}
+Environment=ELASTICSEARCH_HOST={{ amundsen_search_es_host }}
+Environment=ELASTICSEARCH_PORT={{ amundsen_search_es_port }}
+ExecStart={{ amundsen_search_virtualenv }}/bin/gunicorn --workers {{ amundsen_search_gunicorn_workers }} --bind {{ amundsen_search_bind_host }}:{{ amundsen_search_port }} search_service.search_wsgi:app
 Restart=always
 RestartSec=5
 

--- a/src/roles/apache_nifi/defaults/main.yml
+++ b/src/roles/apache_nifi/defaults/main.yml
@@ -1,13 +1,13 @@
 ---
-nifi_version: "2.0.0"
-nifi_install_method: "package"            # package|tarball
-nifi_use_apt_repo: true
-nifi_apt_repo: "deb [trusted=yes] https://archive.apache.org/dist/nifi/{{ nifi_version }}/bin/ ./"
+apache_nifi_version: "2.0.0"
+apache_nifi_install_method: "package"            # package|tarball
+apache_nifi_use_apt_repo: true
+apache_nifi_apt_repo: "deb [trusted=yes] https://archive.apache.org/dist/nifi/{{ apache_nifi_version }}/bin/ ./"
 
-nifi_user: nifi
-nifi_group: nifi
-nifi_home: /opt/nifi
-nifi_conf_dir: "{{ nifi_home }}/conf"
+apache_nifi_user: nifi
+apache_nifi_group: nifi
+apache_nifi_home: /opt/nifi
+apache_nifi_conf_dir: "{{ apache_nifi_home }}/conf"
 
 nifi_cluster_enabled: false
 nifi_zookeeper_connect: ""
@@ -16,10 +16,10 @@ nifi_cluster_protocol_port: 11443
 nifi_enable_https: true
 nifi_listen_port: 8080
 nifi_secure_port: 9443
-nifi_keystore_path: "{{ nifi_conf_dir }}/keystore.jks"
-nifi_keystore_password: changeme
-nifi_truststore_path: "{{ nifi_conf_dir }}/truststore.jks"
-nifi_truststore_password: changeme
+apache_nifi_keystore_path: "{{ apache_nifi_conf_dir }}/keystore.jks"
+apache_nifi_keystore_password: changeme
+apache_nifi_truststore_path: "{{ apache_nifi_conf_dir }}/truststore.jks"
+apache_nifi_truststore_password: changeme
 
 nifi_ldap_url: ""
 nifi_ldap_bind_dn: ""
@@ -28,5 +28,5 @@ nifi_ldap_user_search_base: ""
 nifi_ldap_user_search_filter: ""
 nifi_admin_identity: ""
 
-nifi_elk_integration: false
-nifi_prometheus_integration: false
+apache_nifi_elk_integration: false
+apache_nifi_prometheus_integration: false

--- a/src/roles/apache_nifi/tasks/config.yml
+++ b/src/roles/apache_nifi/tasks/config.yml
@@ -3,9 +3,9 @@
   become: true
   ansible.builtin.template:
     src: nifi.properties.j2
-    dest: "{{ nifi_conf_dir }}/nifi.properties"
-    owner: "{{ nifi_user }}"
-    group: "{{ nifi_group }}"
+    dest: "{{ apache_nifi_conf_dir }}/nifi.properties"
+    owner: "{{ apache_nifi_user }}"
+    group: "{{ apache_nifi_group }}"
     mode: '0640'
   notify: restart nifi
   tags: [nifi, config]
@@ -14,9 +14,9 @@
   become: true
   ansible.builtin.template:
     src: bootstrap.conf.j2
-    dest: "{{ nifi_conf_dir }}/bootstrap.conf"
-    owner: "{{ nifi_user }}"
-    group: "{{ nifi_group }}"
+    dest: "{{ apache_nifi_conf_dir }}/bootstrap.conf"
+    owner: "{{ apache_nifi_user }}"
+    group: "{{ apache_nifi_group }}"
     mode: '0640'
   notify: restart nifi
   tags: [nifi, config]
@@ -25,9 +25,9 @@
   become: true
   ansible.builtin.template:
     src: login-identity-providers.xml.j2
-    dest: "{{ nifi_conf_dir }}/login-identity-providers.xml"
-    owner: "{{ nifi_user }}"
-    group: "{{ nifi_group }}"
+    dest: "{{ apache_nifi_conf_dir }}/login-identity-providers.xml"
+    owner: "{{ apache_nifi_user }}"
+    group: "{{ apache_nifi_group }}"
     mode: '0640'
   notify: restart nifi
   tags: [nifi, config]
@@ -36,9 +36,9 @@
   become: true
   ansible.builtin.template:
     src: authorizers.xml.j2
-    dest: "{{ nifi_conf_dir }}/authorizers.xml"
-    owner: "{{ nifi_user }}"
-    group: "{{ nifi_group }}"
+    dest: "{{ apache_nifi_conf_dir }}/authorizers.xml"
+    owner: "{{ apache_nifi_user }}"
+    group: "{{ apache_nifi_group }}"
     mode: '0640'
   notify: restart nifi
   tags: [nifi, config]
@@ -46,7 +46,7 @@
 - name: Install Filebeat for ELK (optional)
   ansible.builtin.include_role:
     name: elastic.filebeat
-  when: nifi_elk_integration
+  when: apache_nifi_elk_integration
   tags: [nifi, elk]
 
 - name: Configure Filebeat for NiFi logs (optional)
@@ -55,6 +55,6 @@
     src: filebeat-nifi.yml.j2
     dest: /etc/filebeat/conf.d/nifi.yml
     mode: '0644'
-  when: nifi_elk_integration
+  when: apache_nifi_elk_integration
   notify: restart filebeat
   tags: [nifi, elk]

--- a/src/roles/apache_nifi/tasks/install.yml
+++ b/src/roles/apache_nifi/tasks/install.yml
@@ -9,16 +9,16 @@
 - name: Create nifi group
   become: true
   ansible.builtin.group:
-    name: "{{ nifi_group }}"
+    name: "{{ apache_nifi_group }}"
     state: present
   tags: [nifi, users]
 
 - name: Create nifi user
   become: true
   ansible.builtin.user:
-    name: "{{ nifi_user }}"
-    group: "{{ nifi_group }}"
-    home: "{{ nifi_home }}"
+    name: "{{ apache_nifi_user }}"
+    group: "{{ apache_nifi_group }}"
+    home: "{{ apache_nifi_home }}"
     shell: /usr/sbin/nologin
     system: true
   tags: [nifi, users]
@@ -26,9 +26,9 @@
 - name: Add NiFi APT repository
   become: true
   ansible.builtin.apt_repository:
-    repo: "{{ nifi_apt_repo }}"
+    repo: "{{ apache_nifi_apt_repo }}"
     state: present
-  when: nifi_use_apt_repo
+  when: apache_nifi_use_apt_repo
   tags: [nifi, repo]
 
 - name: Install/upgrade NiFi via package
@@ -37,34 +37,34 @@
     name: nifi
     state: present
     update_cache: true
-  when: nifi_install_method == "package"
+  when: apache_nifi_install_method == "package"
   tags: [nifi, install]
 
 - name: Download NiFi tarball
   become: true
   ansible.builtin.get_url:
-    url: "https://archive.apache.org/dist/nifi/{{ nifi_version }}/nifi-{{ nifi_version }}-bin.tar.gz"
-    dest: "/tmp/nifi-{{ nifi_version }}.tar.gz"
+    url: "https://archive.apache.org/dist/nifi/{{ apache_nifi_version }}/nifi-{{ apache_nifi_version }}-bin.tar.gz"
+    dest: "/tmp/nifi-{{ apache_nifi_version }}.tar.gz"
     mode: '0644'
-  when: nifi_install_method == "tarball"
+  when: apache_nifi_install_method == "tarball"
   tags: [nifi, install]
 
 - name: Extract NiFi tarball
   become: true
   ansible.builtin.unarchive:
-    src: "/tmp/nifi-{{ nifi_version }}.tar.gz"
-    dest: "{{ nifi_home }}"
+    src: "/tmp/nifi-{{ apache_nifi_version }}.tar.gz"
+    dest: "{{ apache_nifi_home }}"
     remote_src: true
-    creates: "{{ nifi_home }}/bin/nifi.sh"
-  when: nifi_install_method == "tarball"
+    creates: "{{ apache_nifi_home }}/bin/nifi.sh"
+  when: apache_nifi_install_method == "tarball"
   tags: [nifi, install]
 
 - name: Ensure correct ownership
   become: true
   ansible.builtin.file:
-    path: "{{ nifi_home }}"
+    path: "{{ apache_nifi_home }}"
     state: directory
     recurse: true
-    owner: "{{ nifi_user }}"
-    group: "{{ nifi_group }}"
+    owner: "{{ apache_nifi_user }}"
+    group: "{{ apache_nifi_group }}"
   tags: [nifi, permissions]

--- a/src/roles/apache_nifi/templates/bootstrap.conf.j2
+++ b/src/roles/apache_nifi/templates/bootstrap.conf.j2
@@ -1,4 +1,4 @@
 java=java
 java.arg.1=-Xms512m
 java.arg.2=-Xmx2g
-run.as={{ nifi_user }}
+run.as={{ apache_nifi_user }}

--- a/src/roles/apache_nifi/templates/filebeat-nifi.yml.j2
+++ b/src/roles/apache_nifi/templates/filebeat-nifi.yml.j2
@@ -1,7 +1,7 @@
 filebeat.inputs:
   - type: log
     paths:
-      - "{{ nifi_home }}/logs/*.log"
+      - "{{ apache_nifi_home }}/logs/*.log"
     exclude_files: ['\.gz$']
     fields:
       service: nifi

--- a/src/roles/apache_nifi/templates/nifi.properties.j2
+++ b/src/roles/apache_nifi/templates/nifi.properties.j2
@@ -11,10 +11,10 @@ nifi.cluster.node.protocol.port={{ nifi_cluster_protocol_port }}
 nifi.zookeeper.connect.string={{ nifi_zookeeper_connect }}
 {% endif %}
 
-nifi.security.keystore={{ nifi_keystore_path }}
+nifi.security.keystore={{ apache_nifi_keystore_path }}
 nifi.security.keystoreType=jks
-nifi.security.keystorePasswd={{ nifi_keystore_password }}
-nifi.security.truststore={{ nifi_truststore_path }}
+nifi.security.keystorePasswd={{ apache_nifi_keystore_password }}
+nifi.security.truststore={{ apache_nifi_truststore_path }}
 nifi.security.truststoreType=jks
-nifi.security.truststorePasswd={{ nifi_truststore_password }}
+nifi.security.truststorePasswd={{ apache_nifi_truststore_password }}
 nifi.security.user.login.identity.provider=ldap-provider

--- a/src/roles/bind9/handlers/main.yml
+++ b/src/roles/bind9/handlers/main.yml
@@ -5,3 +5,4 @@
 
 - name: Reload BIND9
   ansible.builtin.command: rndc reload
+  changed_when: false

--- a/src/roles/bind9/tasks/configure.yml
+++ b/src/roles/bind9/tasks/configure.yml
@@ -2,17 +2,26 @@
   ansible.builtin.template:
     src: named.conf.options.j2
     dest: /etc/bind/named.conf.options
+    owner: root
+    group: bind
+    mode: '0644'
   notify: Restart BIND9
 
 - name: Deploy named.conf.local with zone definitions
   ansible.builtin.template:
     src: named.conf.local.j2
     dest: /etc/bind/named.conf.local
+    owner: root
+    group: bind
+    mode: '0644'
   notify: Restart BIND9
 
 - name: Create zone files
   ansible.builtin.template:
     src: zone.db.j2
     dest: "/etc/bind/db.{{ item.name }}"
+    owner: root
+    group: bind
+    mode: '0644'
   loop: "{{ bind9_zones }}"
   notify: Reload BIND9

--- a/src/roles/bind9/tasks/dnssec.yml
+++ b/src/roles/bind9/tasks/dnssec.yml
@@ -19,6 +19,9 @@
   ansible.builtin.template:
     src: key.conf.j2
     dest: "/etc/bind/keys/{{ item.name }}.key"
+    owner: root
+    group: bind
+    mode: '0644'
   loop: "{{ bind9_zones }}"
   when: item.dynamic_updates
   notify: Reload BIND9

--- a/src/roles/bind9/tasks/logging.yml
+++ b/src/roles/bind9/tasks/logging.yml
@@ -9,6 +9,9 @@
 - name: Configure log rotation
   ansible.builtin.copy:
     dest: /etc/logrotate.d/bind9
+    owner: root
+    group: root
+    mode: '0644'
     content: |
       {{ bind9_log_dir }}/*.log {
           weekly

--- a/src/roles/cloudflare/tasks/dns.yml
+++ b/src/roles/cloudflare/tasks/dns.yml
@@ -1,6 +1,6 @@
 ---
 - name: Manage Cloudflare DNS records
-  community.cloudflare.cloudflare_dns:
+  community.general.cloudflare_dns:
     zone: "{{ cloudflare_zone }}"
     record: "{{ item.record }}"
     type: "{{ item.type }}"


### PR DESCRIPTION
## Summary
- set explicit file permissions for bind9 templates
- ensure bind9 reload handler is idempotent
- rename amundsen_search variables to follow role prefix
- rename many apache_nifi variables for linting
- fix FQCN for cloudflare DNS module

## Testing
- `ansible-lint src/roles/bind9 | head -n 5`
- `ansible-lint src/roles/amundsen_search | head -n 5`
- `ansible-lint src/roles/cloudflare | head -n 5`
- `ansible-lint src/roles/apache_nifi | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_683e113bc7e0832ab0cae2abe18f7802