### PR TITLE
Add Molecule scenarios for many roles

### DIFF
--- a/src/roles/amundsen_frontend/molecule/default/converge.yml
+++ b/src/roles/amundsen_frontend/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: amundsen_frontend

--- a/src/roles/amundsen_frontend/molecule/default/molecule.yml
+++ b/src/roles/amundsen_frontend/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: amundsen-frontend-debian
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/amundsen_frontend/molecule/default/tests/test_frontend.py
+++ b/src/roles/amundsen_frontend/molecule/default/tests/test_frontend.py
@@ -1,0 +1,38 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_virtualenv_exists(host):
+    venv = host.file('/opt/amundsen/frontend/venv')
+    assert venv.is_directory
+
+
+def test_package_installed(host):
+    cmd = host.run('/opt/amundsen/frontend/venv/bin/pip show amundsen-frontend')
+    assert cmd.rc == 0
+
+
+def test_config_file(host):
+    cfg = host.file('/opt/amundsen/frontend/venv/config.py')
+    assert cfg.exists
+    assert cfg.contains('SEARCHSERVICE_BASE')
+    assert cfg.contains('METADATASERVICE_BASE')
+
+
+def test_systemd_unit(host):
+    unit = host.file('/etc/systemd/system/amundsen-frontend.service')
+    assert unit.exists
+    assert unit.contains('--bind 0.0.0.0:5000')
+
+
+def test_service_running(host):
+    svc = host.service('amundsen-frontend')
+    assert svc.is_enabled
+    assert svc.is_running
+    sock = host.socket('tcp://0.0.0.0:5000')
+    assert sock.is_listening

--- a/src/roles/amundsen_metadata/molecule/default/converge.yml
+++ b/src/roles/amundsen_metadata/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: amundsen_metadata

--- a/src/roles/amundsen_metadata/molecule/default/molecule.yml
+++ b/src/roles/amundsen_metadata/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: amundsen-metadata-debian
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/amundsen_metadata/molecule/default/tests/test_metadata.py
+++ b/src/roles/amundsen_metadata/molecule/default/tests/test_metadata.py
@@ -1,0 +1,37 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_virtualenv_exists(host):
+    venv = host.file('/opt/amundsen/metadata/venv')
+    assert venv.is_directory
+
+
+def test_package_installed(host):
+    cmd = host.run('/opt/amundsen/metadata/venv/bin/pip show amundsen-metadata')
+    assert cmd.rc == 0
+
+
+def test_config_file(host):
+    cfg = host.file('/opt/amundsen/metadata/venv/config.py')
+    assert cfg.exists
+    assert cfg.contains('NEO4J_ENDPOINT')
+
+
+def test_systemd_unit(host):
+    unit = host.file('/etc/systemd/system/amundsen-metadata.service')
+    assert unit.exists
+    assert unit.contains('--bind 0.0.0.0:5002')
+
+
+def test_service_running(host):
+    svc = host.service('amundsen-metadata')
+    assert svc.is_enabled
+    assert svc.is_running
+    sock = host.socket('tcp://0.0.0.0:5002')
+    assert sock.is_listening

--- a/src/roles/amundsen_search/molecule/default/converge.yml
+++ b/src/roles/amundsen_search/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: amundsen_search

--- a/src/roles/amundsen_search/molecule/default/molecule.yml
+++ b/src/roles/amundsen_search/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: amundsen-search-debian
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/amundsen_search/molecule/default/tests/test_search.py
+++ b/src/roles/amundsen_search/molecule/default/tests/test_search.py
@@ -1,0 +1,37 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_virtualenv_exists(host):
+    venv = host.file('/opt/amundsen/search/venv')
+    assert venv.is_directory
+
+
+def test_package_installed(host):
+    cmd = host.run('/opt/amundsen/search/venv/bin/pip show amundsen-search')
+    assert cmd.rc == 0
+
+
+def test_config_file(host):
+    cfg = host.file('/opt/amundsen/search/venv/config.py')
+    assert cfg.exists
+    assert cfg.contains('ELASTICSEARCH_ENDPOINT')
+
+
+def test_systemd_unit(host):
+    unit = host.file('/etc/systemd/system/amundsen-search.service')
+    assert unit.exists
+    assert unit.contains('--bind 0.0.0.0:5001')
+
+
+def test_service_running(host):
+    svc = host.service('amundsen-search')
+    assert svc.is_enabled
+    assert svc.is_running
+    sock = host.socket('tcp://0.0.0.0:5001')
+    assert sock.is_listening

--- a/src/roles/apache_airflow/molecule/default/tests/test_airflow.py
+++ b/src/roles/apache_airflow/molecule/default/tests/test_airflow.py
@@ -1,5 +1,25 @@
+import os
 import testinfra.utils.ansible_runner
 
-def test_apache_airflow_cli(host):
-    cmd = host.run("airflow version")
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_airflow_cli(host):
+    cmd = host.run('airflow version')
     assert cmd.rc == 0
+
+
+def test_config_file(host):
+    cfg = host.file('/opt/airflow/airflow.cfg')
+    assert cfg.exists
+
+
+def test_services_running(host):
+    for svc in ['airflow-webserver', 'airflow-scheduler']:
+        service = host.service(svc)
+        assert service.is_enabled
+        assert service.is_running
+    assert host.socket('tcp://0.0.0.0:8080').is_listening

--- a/src/roles/apache_nifi/molecule/default/converge.yml
+++ b/src/roles/apache_nifi/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: apache_nifi

--- a/src/roles/apache_nifi/molecule/default/molecule.yml
+++ b/src/roles/apache_nifi/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: nifi-debian
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/apache_nifi/molecule/default/tests/test_nifi.py
+++ b/src/roles/apache_nifi/molecule/default/tests/test_nifi.py
@@ -1,0 +1,33 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_java_installed(host):
+    cmd = host.run('java -version')
+    assert cmd.rc == 0
+
+
+def test_nifi_user(host):
+    assert host.user('nifi').exists
+
+
+def test_install_dir(host):
+    nifi_dir = host.file('/opt/nifi')
+    assert nifi_dir.is_directory
+
+
+def test_config_files(host):
+    assert host.file('/opt/nifi/conf/nifi.properties').exists
+    assert host.file('/opt/nifi/conf/bootstrap.conf').exists
+
+
+def test_service_running(host):
+    svc = host.service('nifi')
+    assert svc.is_enabled
+    assert svc.is_running
+    assert host.socket('tcp://0.0.0.0:9443').is_listening

--- a/src/roles/apache_superset/molecule/default/converge.yml
+++ b/src/roles/apache_superset/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: apache_superset

--- a/src/roles/apache_superset/molecule/default/molecule.yml
+++ b/src/roles/apache_superset/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: superset-debian
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/apache_superset/molecule/default/tests/test_superset.py
+++ b/src/roles/apache_superset/molecule/default/tests/test_superset.py
@@ -1,0 +1,30 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_venv_exists(host):
+    venv = host.file('/opt/superset/venv')
+    assert venv.is_directory
+
+
+def test_superset_cli(host):
+    cmd = host.run('/opt/superset/venv/bin/superset --version')
+    assert cmd.rc == 0
+
+
+def test_config_file(host):
+    cfg = host.file('/etc/superset/superset_config.py')
+    assert cfg.exists
+
+
+def test_service_running(host):
+    svc = host.service('superset')
+    assert svc.is_enabled
+    assert svc.is_running
+    sock = host.socket('tcp://0.0.0.0:8088')
+    assert sock.is_listening

--- a/src/roles/apt_mirror/molecule/default/converge.yml
+++ b/src/roles/apt_mirror/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: apt_mirror

--- a/src/roles/apt_mirror/molecule/default/molecule.yml
+++ b/src/roles/apt_mirror/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: apt-mirror-debian
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/apt_mirror/molecule/default/tests/test_mirror.py
+++ b/src/roles/apt_mirror/molecule/default/tests/test_mirror.py
@@ -1,0 +1,28 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_packages_installed(host):
+    assert host.package('apt-mirror').is_installed
+    assert host.package('apache2').is_installed
+
+
+def test_base_dir(host):
+    d = host.file('/var/spool/apt-mirror')
+    assert d.is_directory
+
+
+def test_config_file(host):
+    cfg = host.file('/etc/apt/mirror.list')
+    assert cfg.exists
+
+
+def test_apache_service(host):
+    svc = host.service('apache2')
+    assert svc.is_enabled
+    assert svc.is_running

--- a/src/roles/apt_mirror_client_setup/molecule/default/converge.yml
+++ b/src/roles/apt_mirror_client_setup/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: apt_mirror_client_setup

--- a/src/roles/apt_mirror_client_setup/molecule/default/molecule.yml
+++ b/src/roles/apt_mirror_client_setup/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: apt-mirror-client-debian
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/apt_mirror_client_setup/molecule/default/tests/test_client_setup.py
+++ b/src/roles/apt_mirror_client_setup/molecule/default/tests/test_client_setup.py
@@ -1,0 +1,13 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_sources_list(host):
+    sources = host.file('/etc/apt/sources.list')
+    assert sources.exists
+    assert 'your-apt-mirror-url' in sources.content_string


### PR DESCRIPTION
## Summary
- add Molecule test scenarios and testinfra cases for Amundsen frontend, metadata and search
- add Molecule tests for Apache Airflow, NiFi and Superset
- add Molecule tests for apt_mirror and apt_mirror_client_setup roles

## Testing
- `pytest --version`
- `pytest -q src/roles/apache_airflow/molecule/default/tests/test_airflow.py` *(fails: ModuleNotFoundError: No module named 'testinfra')*
- `molecule --version`

------
https://chatgpt.com/codex/tasks/task_e_683ee3b42dec832aa7193f28134648ad