### PR TITLE
Add Molecule tests for Jenkins and other roles

### DIFF
--- a/src/roles/glusterfs_setup/molecule/default/converge.yml
+++ b/src/roles/glusterfs_setup/molecule/default/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: glusterfs_setup
+      glusterfs_nodes:
+        - localhost
+        - localhost

--- a/src/roles/glusterfs_setup/molecule/default/molecule.yml
+++ b/src/roles/glusterfs_setup/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: glusterfs
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/glusterfs_setup/molecule/default/tests/test_glusterfs_setup.py
+++ b/src/roles/glusterfs_setup/molecule/default/tests/test_glusterfs_setup.py
@@ -1,0 +1,30 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_package_installed(host):
+    pkg = host.package('glusterfs-server')
+    assert pkg.is_installed
+
+
+def test_service_running(host):
+    service = host.service('glusterfs-server')
+    assert service.is_enabled
+    assert service.is_running
+
+
+def test_brick_directory(host):
+    d = host.file('/glusterfs/brick1/gv0')
+    assert d.is_directory
+    assert d.user == 'root'
+    assert d.group == 'root'
+    assert oct(d.mode) == '0o755'
+
+
+def test_port_listening(host):
+    assert host.socket('tcp://0.0.0.0:24007').is_listening

--- a/src/roles/grafana/molecule/default/converge.yml
+++ b/src/roles/grafana/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: grafana
+      grafana_admin_password: admin

--- a/src/roles/grafana/molecule/default/molecule.yml
+++ b/src/roles/grafana/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: grafana
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/grafana/molecule/default/tests/test_grafana.py
+++ b/src/roles/grafana/molecule/default/tests/test_grafana.py
@@ -1,0 +1,28 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_package_installed(host):
+    pkg = host.package('grafana')
+    assert pkg.is_installed
+
+
+def test_service_running(host):
+    service = host.service('grafana-server')
+    assert service.is_enabled
+    assert service.is_running
+
+
+def test_config_file(host):
+    cfg = host.file('/etc/grafana/grafana.ini')
+    assert cfg.exists
+    assert cfg.user == 'root'
+
+
+def test_port_listening(host):
+    assert host.socket('tcp://0.0.0.0:3000').is_listening

--- a/src/roles/ha_proxy_load_balancer_setup/molecule/default/converge.yml
+++ b/src/roles/ha_proxy_load_balancer_setup/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: ha_proxy_load_balancer_setup

--- a/src/roles/ha_proxy_load_balancer_setup/molecule/default/molecule.yml
+++ b/src/roles/ha_proxy_load_balancer_setup/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: haproxy-lb
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/ha_proxy_load_balancer_setup/molecule/default/tests/test_haproxy_lb.py
+++ b/src/roles/ha_proxy_load_balancer_setup/molecule/default/tests/test_haproxy_lb.py
@@ -1,0 +1,35 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_package_installed(host):
+    assert host.package('haproxy').is_installed
+
+
+def test_service_running(host):
+    service = host.service('haproxy')
+    assert service.is_enabled
+    assert service.is_running
+
+
+def test_config_file(host):
+    cfg = host.file('/etc/haproxy/haproxy.cfg')
+    assert cfg.exists
+    assert cfg.contains('frontend http_frontend')
+    assert cfg.contains('backend http_backend')
+
+
+def test_error_files(host):
+    for code in ['400','403','408','500','502','503','504']:
+        f = host.file(f'/etc/haproxy/errors/{code}.http')
+        assert f.exists
+        assert oct(f.mode) == '0o644'
+
+
+def test_port_listening(host):
+    assert host.socket('tcp://0.0.0.0:80').is_listening

--- a/src/roles/haproxy/molecule/default/converge.yml
+++ b/src/roles/haproxy/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: haproxy

--- a/src/roles/haproxy/molecule/default/molecule.yml
+++ b/src/roles/haproxy/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: haproxy
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/haproxy/molecule/default/tests/test_haproxy.py
+++ b/src/roles/haproxy/molecule/default/tests/test_haproxy.py
@@ -1,0 +1,27 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_package_installed(host):
+    assert host.package('haproxy').is_installed
+
+
+def test_service_running(host):
+    service = host.service('haproxy')
+    assert service.is_enabled
+    assert service.is_running
+
+
+def test_config_file(host):
+    cfg = host.file('/etc/haproxy/haproxy.cfg')
+    assert cfg.exists
+    assert cfg.contains('frontend')
+
+
+def test_port_listening(host):
+    assert host.socket('tcp://0.0.0.0:80').is_listening

--- a/src/roles/itop/molecule/default/converge.yml
+++ b/src/roles/itop/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: itop

--- a/src/roles/itop/molecule/default/molecule.yml
+++ b/src/roles/itop/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: itop
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/itop/molecule/default/tests/test_itop.py
+++ b/src/roles/itop/molecule/default/tests/test_itop.py
@@ -1,0 +1,24 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_web_root(host):
+    d = host.file('/var/www/html/itop')
+    assert d.is_directory
+    assert d.user == 'www-data'
+
+
+def test_index_present(host):
+    f = host.file('/var/www/html/itop/index.php')
+    assert f.exists
+
+
+def test_database(host):
+    cmd = host.run("mysql -uitop_user -pitop_password -e 'SHOW DATABASES LIKE \"itop_db\";'")
+    assert cmd.rc == 0
+    assert 'itop_db' in cmd.stdout

--- a/src/roles/jenkins_agent/molecule/default/converge.yml
+++ b/src/roles/jenkins_agent/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: jenkins_agent
+      jenkins_agent_ssh_public_key: "ssh-rsa AAAAB3NzaD dummykey"

--- a/src/roles/jenkins_agent/molecule/default/molecule.yml
+++ b/src/roles/jenkins_agent/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: jenkins-agent
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/jenkins_agent/molecule/default/tests/test_jenkins_agent.py
+++ b/src/roles/jenkins_agent/molecule/default/tests/test_jenkins_agent.py
@@ -1,0 +1,24 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_user_exists(host):
+    user = host.user('jenkins')
+    assert user.exists
+    assert user.shell == '/bin/bash'
+
+
+def test_java_installed(host):
+    assert host.package('openjdk-11-jdk').is_installed
+
+
+def test_authorized_key(host):
+    f = host.file('/home/jenkins/.ssh/authorized_keys')
+    assert f.exists
+    assert f.user == 'jenkins'
+    assert f.mode == 0o600

--- a/src/roles/jenkins_backup/molecule/default/converge.yml
+++ b/src/roles/jenkins_backup/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: jenkins_backup

--- a/src/roles/jenkins_backup/molecule/default/molecule.yml
+++ b/src/roles/jenkins_backup/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: jenkins-backup
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/jenkins_backup/molecule/default/tests/test_jenkins_backup.py
+++ b/src/roles/jenkins_backup/molecule/default/tests/test_jenkins_backup.py
@@ -1,0 +1,17 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_backup_dir(host):
+    d = host.file('/var/backups/jenkins')
+    assert d.is_directory
+
+
+def test_backup_file_exists(host):
+    backups = host.run("ls /var/backups/jenkins/jenkins-*.tar.gz")
+    assert backups.rc == 0

--- a/src/roles/jenkins_controller/molecule/default/converge.yml
+++ b/src/roles/jenkins_controller/molecule/default/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: jenkins_controller
+      jenkins_admin_password: admin
+      jenkins_version: "2.452.2"
+      jenkins_plugins:
+        - git

--- a/src/roles/jenkins_controller/molecule/default/molecule.yml
+++ b/src/roles/jenkins_controller/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: jenkins-controller
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/jenkins_controller/molecule/default/tests/test_jenkins_controller.py
+++ b/src/roles/jenkins_controller/molecule/default/tests/test_jenkins_controller.py
@@ -1,0 +1,28 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_package_installed(host):
+    assert host.package('jenkins').is_installed
+
+
+def test_service_running(host):
+    service = host.service('jenkins')
+    assert service.is_enabled
+    assert service.is_running
+
+
+def test_port_listening(host):
+    assert host.socket('tcp://0.0.0.0:8080').is_listening
+
+
+def test_init_groovy(host):
+    f = host.file('/var/lib/jenkins/init.groovy.d/init_admin_user.groovy')
+    assert f.exists
+    assert f.user == 'jenkins'
+    assert oct(f.mode) == '0o644'


### PR DESCRIPTION
## Summary
- create Molecule scenarios for glusterfs_setup
- add grafana Molecule scenario
- add HAProxy load balancer tests
- cover haproxy role
- add itop role tests
- jenkins_agent Molecule tests
- add Molecule tests for jenkins_backup and controller

## Testing
- `ansible-lint` *(fails: 131 failure(s))*

------
https://chatgpt.com/codex/tasks/task_e_683ee8c4ddd4832a91a74ca429a79fda