### PR TITLE
Add Molecule tests for Elasticsearch and Filebeat roles

### DIFF
--- a/src/roles/elasticsearch_cluster/molecule/default/converge.yml
+++ b/src/roles/elasticsearch_cluster/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: elasticsearch_cluster

--- a/src/roles/elasticsearch_cluster/molecule/default/molecule.yml
+++ b/src/roles/elasticsearch_cluster/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: /lib/systemd/systemd
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/src/roles/elasticsearch_cluster/molecule/default/tests/test_cluster.py
+++ b/src/roles/elasticsearch_cluster/molecule/default/tests/test_cluster.py
@@ -1,0 +1,22 @@
+import os
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+def test_config_file(host):
+    cfg = host.file('/etc/elasticsearch/elasticsearch.yml')
+    assert cfg.exists
+    assert 'cluster.name' in cfg.content_string
+
+def test_heap_file(host):
+    heap = host.file('/etc/elasticsearch/jvm.options.d/heap_size.options')
+    assert heap.exists
+    assert '-Xms' in heap.content_string
+
+def test_service_running(host):
+    svc = host.service('elasticsearch')
+    assert svc.is_enabled
+    assert svc.is_running
+    assert host.socket('tcp://0.0.0.0:9200').is_listening

--- a/src/roles/elasticsearch_config/molecule/default/converge.yml
+++ b/src/roles/elasticsearch_config/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: elasticsearch_install
+    - role: elasticsearch_config

--- a/src/roles/elasticsearch_config/molecule/default/molecule.yml
+++ b/src/roles/elasticsearch_config/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: /lib/systemd/systemd
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/src/roles/elasticsearch_config/molecule/default/tests/test_config.py
+++ b/src/roles/elasticsearch_config/molecule/default/tests/test_config.py
@@ -1,0 +1,17 @@
+import os
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+def test_elasticsearch_yml(host):
+    cfg = host.file('/etc/elasticsearch/elasticsearch.yml')
+    assert cfg.exists
+    assert 'cluster.name' in cfg.content_string
+
+def test_heap_file(host):
+    heap = host.file('/etc/elasticsearch/jvm.options.d/heap.options')
+    assert heap.exists
+    assert '-Xms' in heap.content_string
+    assert '-Xmx' in heap.content_string

--- a/src/roles/elasticsearch_install/molecule/default/converge.yml
+++ b/src/roles/elasticsearch_install/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: elasticsearch_install

--- a/src/roles/elasticsearch_install/molecule/default/molecule.yml
+++ b/src/roles/elasticsearch_install/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: /lib/systemd/systemd
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/src/roles/elasticsearch_install/molecule/default/tests/test_install.py
+++ b/src/roles/elasticsearch_install/molecule/default/tests/test_install.py
@@ -1,0 +1,19 @@
+import os
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+def test_repo_file(host):
+    f = host.file('/etc/apt/sources.list.d/elasticsearch.list')
+    assert f.exists
+    assert 'artifacts.elastic.co' in f.content_string
+
+def test_package_installed(host):
+    pkg = host.package('elasticsearch')
+    assert pkg.is_installed
+
+def test_service_enabled(host):
+    svc = host.service('elasticsearch')
+    assert svc.is_enabled

--- a/src/roles/elasticsearch_security/molecule/default/converge.yml
+++ b/src/roles/elasticsearch_security/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: elasticsearch_install
+    - role: elasticsearch_config
+    - role: elasticsearch_security

--- a/src/roles/elasticsearch_security/molecule/default/molecule.yml
+++ b/src/roles/elasticsearch_security/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: /lib/systemd/systemd
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/src/roles/elasticsearch_security/molecule/default/tests/test_security.py
+++ b/src/roles/elasticsearch_security/molecule/default/tests/test_security.py
@@ -1,0 +1,16 @@
+import os
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+def test_cert_directory(host):
+    d = host.file('/etc/elasticsearch/certs')
+    assert d.is_directory
+    assert d.user == 'root'
+    assert d.group == 'elasticsearch'
+
+def test_role_mapping(host):
+    mapping = host.file('/etc/elasticsearch/role_mapping.yml')
+    assert mapping.exists

--- a/src/roles/elasticsearch_snapshot/molecule/default/converge.yml
+++ b/src/roles/elasticsearch_snapshot/molecule/default/converge.yml
@@ -1,0 +1,14 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    elasticsearch_snapshot_use_slm: false
+    es_snapshot_repo_name: testrepo
+    es_snapshot_repo_type: fs
+    es_snapshot_repo_settings:
+      location: /tmp/es_snapshots
+      compress: true
+  roles:
+    - role: elasticsearch_cluster
+    - role: elasticsearch_snapshot

--- a/src/roles/elasticsearch_snapshot/molecule/default/molecule.yml
+++ b/src/roles/elasticsearch_snapshot/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: /lib/systemd/systemd
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/src/roles/elasticsearch_snapshot/molecule/default/tests/test_snapshot.py
+++ b/src/roles/elasticsearch_snapshot/molecule/default/tests/test_snapshot.py
@@ -1,0 +1,15 @@
+import os
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+def test_snapshot_script(host):
+    script = host.file('/usr/local/bin/es_snapshot.sh')
+    assert script.exists
+    assert script.mode & 0o111
+
+def test_cron_job(host):
+    cron = host.check_output('crontab -l -u root')
+    assert '/usr/local/bin/es_snapshot.sh' in cron

--- a/src/roles/filebeat/molecule/default/converge.yml
+++ b/src/roles/filebeat/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: elasticsearch_install
+    - role: filebeat

--- a/src/roles/filebeat/molecule/default/molecule.yml
+++ b/src/roles/filebeat/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    command: /lib/systemd/systemd
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/src/roles/filebeat/molecule/default/tests/test_filebeat.py
+++ b/src/roles/filebeat/molecule/default/tests/test_filebeat.py
@@ -1,0 +1,20 @@
+import os
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+def test_filebeat_package(host):
+    pkg = host.package('filebeat')
+    assert pkg.is_installed
+
+def test_config_file(host):
+    cfg = host.file('/etc/filebeat/filebeat.yml')
+    assert cfg.exists
+    assert 'filebeat.inputs' in cfg.content_string
+
+def test_service_running(host):
+    svc = host.service('filebeat')
+    assert svc.is_enabled
+    assert svc.is_running


### PR DESCRIPTION
## Summary
- add molecule scenarios for elasticsearch install/config/cluster/security/snapshot
- add molecule scenario for filebeat role

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ee8e5b978832ab057f9c8c35e174e