### PR TITLE
Add Molecule tests for key roles

### DIFF
--- a/src/roles/spark_role/molecule/default/converge.yml
+++ b/src/roles/spark_role/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: spark_role
+      vars:
+        spark_role_history_enabled: true

--- a/src/roles/spark_role/molecule/default/molecule.yml
+++ b/src/roles/spark_role/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: spark
+    image: geerlingguy/docker-debian12-ansible:latest
+    command: /lib/systemd/systemd
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: testinfra

--- a/src/roles/spark_role/molecule/default/tests/test_spark.py
+++ b/src/roles/spark_role/molecule/default/tests/test_spark.py
@@ -1,0 +1,55 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_packages_installed(host):
+    assert host.package('openjdk-17-jdk').is_installed
+
+
+def test_user_exists(host):
+    u = host.user('spark')
+    assert u.exists
+
+
+def test_install_dir(host):
+    d = host.file('/opt/spark/current')
+    assert d.is_directory
+
+
+def test_master_service(host):
+    svc = host.service('spark-master')
+    assert svc.is_enabled
+    assert svc.is_running
+
+
+def test_worker_service(host):
+    svc = host.service('spark-worker')
+    assert svc.is_enabled
+    assert svc.is_running
+
+
+def test_history_service(host):
+    svc = host.service('spark-history-server')
+    assert svc.is_enabled
+    assert svc.is_running
+
+
+def test_ports(host):
+    assert host.socket('tcp://0.0.0.0:7077').is_listening
+    assert host.socket('tcp://0.0.0.0:8080').is_listening
+    assert host.socket('tcp://0.0.0.0:8081').is_listening
+    assert host.socket('tcp://0.0.0.0:18080').is_listening
+
+
+def test_config_files(host):
+    defaults = host.file('/opt/spark/current/conf/spark-defaults.conf')
+    env = host.file('/opt/spark/current/conf/spark-env.sh')
+    assert defaults.contains('spark.eventLog.enabled true')
+    assert defaults.contains('/var/spark-events')
+    assert env.contains('SPARK_WORKER_MEMORY')
+

--- a/src/roles/sshd/molecule/default/converge.yml
+++ b/src/roles/sshd/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: sshd
+      vars:
+        sshd_listen_address: "0.0.0.0"

--- a/src/roles/sshd/molecule/default/molecule.yml
+++ b/src/roles/sshd/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: sshd
+    image: geerlingguy/docker-debian12-ansible:latest
+    command: /lib/systemd/systemd
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: testinfra

--- a/src/roles/sshd/molecule/default/tests/test_sshd.py
+++ b/src/roles/sshd/molecule/default/tests/test_sshd.py
@@ -1,0 +1,28 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_package_installed(host):
+    assert host.package('openssh-server').is_installed
+
+
+def test_service_running(host):
+    svc = host.service('sshd')
+    assert svc.is_enabled
+    assert svc.is_running
+
+
+def test_port_listening(host):
+    assert host.socket('tcp://0.0.0.0:22').is_listening
+
+
+def test_config(host):
+    cfg = host.file('/etc/ssh/sshd_config')
+    assert cfg.contains('PermitRootLogin no')
+    assert cfg.contains('PasswordAuthentication')
+

--- a/src/roles/step_ca/molecule/default/converge.yml
+++ b/src/roles/step_ca/molecule/default/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    step_ca_bootstrap: true
+    step_ca_dns_names:
+      - localhost
+  roles:
+    - step_ca

--- a/src/roles/step_ca/molecule/default/molecule.yml
+++ b/src/roles/step_ca/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: stepca
+    image: geerlingguy/docker-debian12-ansible:latest
+    command: /lib/systemd/systemd
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: testinfra

--- a/src/roles/step_ca/molecule/default/tests/test_step_ca.py
+++ b/src/roles/step_ca/molecule/default/tests/test_step_ca.py
@@ -1,0 +1,34 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_packages_installed(host):
+    assert host.package('step-ca').is_installed
+    assert host.package('step').is_installed
+
+
+def test_user(host):
+    u = host.user('step')
+    assert u.exists
+
+
+def test_config_file(host):
+    f = host.file('/home/step/.step/config/ca.json')
+    assert f.exists
+    assert f.user == 'step'
+
+
+def test_service(host):
+    svc = host.service('step-ca')
+    assert svc.is_enabled
+    assert svc.is_running
+
+
+def test_port(host):
+    assert host.socket('tcp://0.0.0.0:8443').is_listening
+

--- a/src/roles/ufw/molecule/default/converge.yml
+++ b/src/roles/ufw/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - ufw

--- a/src/roles/ufw/molecule/default/molecule.yml
+++ b/src/roles/ufw/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: ufw
+    image: geerlingguy/docker-debian12-ansible:latest
+    command: /lib/systemd/systemd
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: testinfra

--- a/src/roles/ufw/molecule/default/tests/test_ufw.py
+++ b/src/roles/ufw/molecule/default/tests/test_ufw.py
@@ -1,0 +1,24 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_package_installed(host):
+    assert host.package('ufw').is_installed
+
+
+def test_service_running(host):
+    svc = host.service('ufw')
+    assert svc.is_enabled
+    assert svc.is_running
+
+
+def test_status(host):
+    cmd = host.run('ufw status')
+    assert 'Status: active' in cmd.stdout
+    assert '22/tcp' in cmd.stdout
+

--- a/src/roles/update_system/molecule/default/converge.yml
+++ b/src/roles/update_system/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - update_system

--- a/src/roles/update_system/molecule/default/molecule.yml
+++ b/src/roles/update_system/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: update
+    image: geerlingguy/docker-debian12-ansible:latest
+    command: /lib/systemd/systemd
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: testinfra

--- a/src/roles/update_system/molecule/default/tests/test_update_system.py
+++ b/src/roles/update_system/molecule/default/tests/test_update_system.py
@@ -1,0 +1,13 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_no_upgrades(host):
+    cmd = host.run('apt list --upgradeable')
+    assert 'upgradable from' not in cmd.stdout
+

--- a/src/roles/vault/molecule/default/converge.yml
+++ b/src/roles/vault/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - vault

--- a/src/roles/vault/molecule/default/molecule.yml
+++ b/src/roles/vault/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: vault
+    image: geerlingguy/docker-debian12-ansible:latest
+    command: /lib/systemd/systemd
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: testinfra

--- a/src/roles/vault/molecule/default/tests/test_vault.py
+++ b/src/roles/vault/molecule/default/tests/test_vault.py
@@ -1,0 +1,28 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_package_installed(host):
+    assert host.package('vault').is_installed
+
+
+def test_service_running(host):
+    svc = host.service('vault')
+    assert svc.is_enabled
+    assert svc.is_running
+
+
+def test_config_file(host):
+    cfg = host.file('/etc/vault/vault.hcl')
+    assert cfg.exists
+    assert cfg.contains('listener "tcp"')
+
+
+def test_port(host):
+    assert host.socket('tcp://0.0.0.0:8200').is_listening
+


### PR DESCRIPTION
## Summary
- add Molecule scenarios for `spark_role`, `sshd`, `step_ca`, `ufw`, `update_system`, and `vault`
- include testinfra-based verification for packages, services, configs and ports

## Testing
- `ansible-lint src/roles/spark_role`
- `ansible-lint src/roles/sshd`
- `ansible-lint src/roles/step_ca`
- `ansible-lint src/roles/ufw`
- `ansible-lint src/roles/update_system`
- `ansible-lint src/roles/vault`
- `molecule test -s default` *(fails: Failed to find driver docker)*

------
https://chatgpt.com/codex/tasks/task_e_683ef75665a8832abc7929f6487503ca