### PR TITLE
Add molecule tests

### DIFF
--- a/src/roles/postgres_backup/molecule/default/converge.yml
+++ b/src/roles/postgres_backup/molecule/default/converge.yml
@@ -1,0 +1,25 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    db_name: testdb
+    db_user: postgres
+  tasks:
+    - name: Install PostgreSQL server
+      apt:
+        name: postgresql
+        state: present
+        update_cache: true
+
+    - name: Ensure database exists
+      become_user: postgres
+      postgresql_db:
+        name: "{{ db_name }}"
+      ignore_errors: true
+
+  roles:
+    - role: postgres_backup
+      db_name: "{{ db_name }}"
+      db_user: "{{ db_user }}"
+      backup_dir: /var/backups/postgres

--- a/src/roles/postgres_backup/molecule/default/molecule.yml
+++ b/src/roles/postgres_backup/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: postgres
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/postgres_backup/molecule/default/tests/test_backup.py
+++ b/src/roles/postgres_backup/molecule/default/tests/test_backup.py
@@ -1,0 +1,30 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_backup_dir_exists(host):
+    d = host.file('/var/backups/postgres')
+    assert d.is_directory
+
+
+def test_backup_script(host):
+    f = host.file('/usr/local/bin/backup_postgres.sh')
+    assert f.exists
+    assert f.mode & 0o111
+
+
+def test_systemd_units(host):
+    svc = host.file('/etc/systemd/system/postgres_backup.service')
+    timer = host.file('/etc/systemd/system/postgres_backup.timer')
+    assert svc.exists
+    assert timer.exists
+
+
+def test_timer_enabled(host):
+    timer = host.service('postgres_backup.timer')
+    assert timer.is_enabled

--- a/src/roles/postgresql/molecule/default/converge.yml
+++ b/src/roles/postgresql/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: postgresql
+      postgresql_admin_password: secret

--- a/src/roles/postgresql/molecule/default/molecule.yml
+++ b/src/roles/postgresql/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: postgres
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/postgresql/molecule/default/tests/test_postgresql.py
+++ b/src/roles/postgresql/molecule/default/tests/test_postgresql.py
@@ -1,0 +1,23 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_service_running(host):
+    service = host.service('postgresql')
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_port_listening(host):
+    assert host.socket('tcp://0.0.0.0:5432').is_listening
+
+
+def test_config(host):
+    cfg = host.file('/etc/postgresql/15/main/postgresql.conf')
+    assert cfg.exists
+    assert 'scram-sha-256' in cfg.content_string

--- a/src/roles/postgresql_client/molecule/default/converge.yml
+++ b/src/roles/postgresql_client/molecule/default/converge.yml
@@ -1,0 +1,28 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    keycloak_db_name: keycloak
+    keycloak_db_host: localhost
+    keycloak_db_user: keycloak
+    keycloak_db_password: changeme
+  tasks:
+    - name: Install PostgreSQL server
+      apt:
+        name: postgresql
+        state: present
+        update_cache: true
+
+    - name: Ensure postgres is running
+      service:
+        name: postgresql
+        state: started
+        enabled: true
+
+  roles:
+    - role: postgresql_client
+      keycloak_db_name: "{{ keycloak_db_name }}"
+      keycloak_db_host: "{{ keycloak_db_host }}"
+      keycloak_db_user: "{{ keycloak_db_user }}"
+      keycloak_db_password: "{{ keycloak_db_password }}"

--- a/src/roles/postgresql_client/molecule/default/molecule.yml
+++ b/src/roles/postgresql_client/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: pgclient
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/postgresql_client/molecule/default/tests/test_client.py
+++ b/src/roles/postgresql_client/molecule/default/tests/test_client.py
@@ -1,0 +1,23 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_client_installed(host):
+    assert host.package('postgresql-client').is_installed
+
+
+def test_database_created(host):
+    cmd = host.run("psql -U postgres -tAc 'SELECT 1 FROM pg_database WHERE datname=\'keycloak\''")
+    assert cmd.rc == 0
+    assert '1' in cmd.stdout
+
+
+def test_user_created(host):
+    cmd = host.run("psql -U postgres -tAc 'SELECT 1 FROM pg_roles WHERE rolname=\'keycloak\''")
+    assert cmd.rc == 0
+    assert '1' in cmd.stdout

--- a/src/roles/prometheus/molecule/default/converge.yml
+++ b/src/roles/prometheus/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: prometheus

--- a/src/roles/prometheus/molecule/default/molecule.yml
+++ b/src/roles/prometheus/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: prometheus
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/prometheus/molecule/default/tests/test_prometheus.py
+++ b/src/roles/prometheus/molecule/default/tests/test_prometheus.py
@@ -1,0 +1,25 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_prometheus_service(host):
+    service = host.service('prometheus')
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_node_exporter_service(host):
+    service = host.service('prometheus-node-exporter')
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_config_file(host):
+    cfg = host.file('/etc/prometheus/prometheus.yml')
+    assert cfg.exists
+    assert 'scrape_interval' in cfg.content_string

--- a/src/roles/python_git_repo_service_install/molecule/default/converge.yml
+++ b/src/roles/python_git_repo_service_install/molecule/default/converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    app_name: myapp
+    app_repo: https://example.com/repo.git
+  roles:
+    - role: python_git_repo_service_install
+      app_name: "{{ app_name }}"
+      app_repo: "{{ app_repo }}"

--- a/src/roles/python_git_repo_service_install/molecule/default/molecule.yml
+++ b/src/roles/python_git_repo_service_install/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: app
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/python_git_repo_service_install/molecule/default/tests/test_app.py
+++ b/src/roles/python_git_repo_service_install/molecule/default/tests/test_app.py
@@ -1,0 +1,22 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_repo_cloned(host):
+    d = host.file('/opt/myapp')
+    assert d.is_directory
+
+
+def test_service_file(host):
+    f = host.file('/etc/systemd/system/myapp.service')
+    assert f.exists
+
+
+def test_service_running(host):
+    s = host.service('myapp')
+    assert s.is_enabled

--- a/src/roles/remove_unnecessary_packages/molecule/default/converge.yml
+++ b/src/roles/remove_unnecessary_packages/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: remove_unnecessary_packages

--- a/src/roles/remove_unnecessary_packages/molecule/default/molecule.yml
+++ b/src/roles/remove_unnecessary_packages/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: cleanup
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/remove_unnecessary_packages/molecule/default/tests/test_remove.py
+++ b/src/roles/remove_unnecessary_packages/molecule/default/tests/test_remove.py
@@ -1,0 +1,15 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_telnet_removed(host):
+    assert not host.package('telnet').is_installed
+
+
+def test_ftp_removed(host):
+    assert not host.package('ftp').is_installed


### PR DESCRIPTION
## Summary
- add molecule scenarios and tests for roles: postgres_backup, postgresql, postgresql_client, prometheus, python_git_repo_service_install and remove_unnecessary_packages

## Testing
- `molecule --version`
- `molecule test --destroy never` *(fails: MoleculeError during driver init)*

------
https://chatgpt.com/codex/tasks/task_e_683ef79583a4832a91b76eedc151317d