### PR TITLE
Add Kafka broker role

### DIFF
--- a/docs/kafka-role.md
+++ b/docs/kafka-role.md
@@ -1,0 +1,31 @@
+# Kafka Broker Role
+
+## Overview
+
+The **kafka_broker** role installs Apache Kafka on Debian-based systems and configures it as a systemd service. It can be used for simple single-node setups or as part of a larger cluster with multiple brokers and ZooKeeper nodes.
+
+## Supported Operating Systems/Platforms
+
+- Debian 11/12
+- Ubuntu 20.04/22.04
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_broker_version` | `"3.5.2"` | Kafka release to install |
+| `kafka_broker_scala_version` | `"2.13"` | Scala version for binaries |
+| `kafka_broker_install_dir` | `/opt/kafka` | Installation base directory |
+| `kafka_broker_data_dir` | `/var/lib/kafka` | Directory for Kafka logs |
+| `kafka_broker_user` | `kafka` | Service user |
+| `kafka_broker_listeners` | `PLAINTEXT://0.0.0.0:9092` | Listener string |
+| `kafka_broker_zookeeper_connect` | `localhost:2181` | ZooKeeper connection |
+
+## Example Playbook
+
+```yaml
+- hosts: kafka_brokers
+  become: true
+  roles:
+    - kafka_broker
+```

--- a/src/roles/kafka_broker/README.md
+++ b/src/roles/kafka_broker/README.md
@@ -1,0 +1,27 @@
+# Ansible Role: kafka_broker
+
+This role installs and configures an Apache Kafka broker on Debian/Ubuntu hosts. It downloads the Kafka binaries, deploys a minimal `server.properties` configuration and sets up Kafka as a systemd service.
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `kafka_broker_version` | `"3.5.2"` | Kafka version to install |
+| `kafka_broker_scala_version` | `"2.13"` | Scala build of Kafka |
+| `kafka_broker_install_dir` | `/opt/kafka` | Base installation directory |
+| `kafka_broker_data_dir` | `/var/lib/kafka` | Data directory for logs |
+| `kafka_broker_user` | `kafka` | User to run the service |
+| `kafka_broker_group` | `kafka` | Group for the service |
+| `kafka_broker_listeners` | `PLAINTEXT://0.0.0.0:9092` | Listener configuration |
+| `kafka_broker_zookeeper_connect` | `localhost:2181` | ZooKeeper connection |
+
+## Example Playbook
+
+```yaml
+- hosts: kafka_brokers
+  become: true
+  roles:
+    - kafka_broker
+```
+
+The role assumes a ZooKeeper instance is reachable using `kafka_zookeeper_connect` unless you adapt the configuration for KRaft.

--- a/src/roles/kafka_broker/defaults/main.yml
+++ b/src/roles/kafka_broker/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+kafka_broker_version: "3.5.2"
+kafka_broker_scala_version: "2.13"
+kafka_broker_download_url: "https://downloads.apache.org/kafka/{{ kafka_broker_version }}/kafka_{{ kafka_broker_scala_version }}-{{ kafka_broker_version }}.tgz"
+
+kafka_broker_install_dir: "/opt/kafka"
+kafka_broker_home: "{{ kafka_broker_install_dir }}/kafka_{{ kafka_broker_scala_version }}-{{ kafka_broker_version }}"
+
+kafka_broker_user: "kafka"
+kafka_broker_group: "kafka"
+
+kafka_broker_data_dir: "/var/lib/kafka"
+
+kafka_broker_java_package: "openjdk-17-jdk"
+
+kafka_broker_heap_opts: "-Xmx1G -Xms1G"
+kafka_broker_listeners: "PLAINTEXT://0.0.0.0:9092"
+kafka_broker_zookeeper_connect: "localhost:2181"

--- a/src/roles/kafka_broker/handlers/main.yml
+++ b/src/roles/kafka_broker/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Restart Kafka
+  ansible.builtin.systemd:
+    name: kafka
+    state: restarted

--- a/src/roles/kafka_broker/meta/main.yml
+++ b/src/roles/kafka_broker/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/src/roles/kafka_broker/tasks/config.yml
+++ b/src/roles/kafka_broker/tasks/config.yml
@@ -1,0 +1,26 @@
+---
+- name: Deploy environment file
+  ansible.builtin.template:
+    src: kafka.env.j2
+    dest: /etc/default/kafka
+    mode: "0644"
+  notify: Restart Kafka
+  become: true
+
+- name: Deploy server.properties
+  ansible.builtin.template:
+    src: server.properties.j2
+    dest: "{{ kafka_broker_home }}/config/server.properties"
+    owner: "{{ kafka_broker_user }}"
+    group: "{{ kafka_broker_group }}"
+    mode: "0644"
+  notify: Restart Kafka
+  become: true
+
+- name: Deploy systemd unit
+  ansible.builtin.template:
+    src: kafka.service.j2
+    dest: /etc/systemd/system/kafka.service
+    mode: "0644"
+  notify: Reload systemd
+  become: true

--- a/src/roles/kafka_broker/tasks/install.yml
+++ b/src/roles/kafka_broker/tasks/install.yml
@@ -1,0 +1,58 @@
+---
+- name: Install Java runtime
+  ansible.builtin.apt:
+    name: "{{ kafka_broker_java_package }}"
+    state: present
+    update_cache: true
+  become: true
+
+- name: Create kafka group
+  ansible.builtin.group:
+    name: "{{ kafka_broker_group }}"
+    system: true
+  become: true
+
+- name: Create kafka user
+  ansible.builtin.user:
+    name: "{{ kafka_broker_user }}"
+    group: "{{ kafka_broker_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+  become: true
+
+- name: Create installation directory
+  ansible.builtin.file:
+    path: "{{ kafka_broker_install_dir }}"
+    state: directory
+    owner: "{{ kafka_broker_user }}"
+    group: "{{ kafka_broker_group }}"
+    mode: "0755"
+  become: true
+
+- name: Create data directory
+  ansible.builtin.file:
+    path: "{{ kafka_broker_data_dir }}"
+    state: directory
+    owner: "{{ kafka_broker_user }}"
+    group: "{{ kafka_broker_group }}"
+    mode: "0755"
+  become: true
+
+- name: Download Kafka archive
+  ansible.builtin.get_url:
+    url: "{{ kafka_broker_download_url }}"
+    dest: "/tmp/kafka_{{ kafka_broker_scala_version }}-{{ kafka_broker_version }}.tgz"
+    mode: "0644"
+    force: false
+  become: true
+
+- name: Unpack Kafka
+  ansible.builtin.unarchive:
+    src: "/tmp/kafka_{{ kafka_broker_scala_version }}-{{ kafka_broker_version }}.tgz"
+    dest: "{{ kafka_broker_install_dir }}"
+    owner: "{{ kafka_broker_user }}"
+    group: "{{ kafka_broker_group }}"
+    remote_src: true
+    creates: "{{ kafka_broker_home }}/bin/kafka-server-start.sh"
+  become: true

--- a/src/roles/kafka_broker/tasks/main.yml
+++ b/src/roles/kafka_broker/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Include installation tasks
+  ansible.builtin.import_tasks: install.yml
+
+- name: Include configuration tasks
+  ansible.builtin.import_tasks: config.yml
+
+- name: Include service tasks
+  ansible.builtin.import_tasks: service.yml

--- a/src/roles/kafka_broker/tasks/service.yml
+++ b/src/roles/kafka_broker/tasks/service.yml
@@ -1,0 +1,7 @@
+---
+- name: Ensure Kafka is enabled and started
+  ansible.builtin.systemd:
+    name: kafka
+    enabled: true
+    state: started
+  become: true

--- a/src/roles/kafka_broker/templates/kafka.env.j2
+++ b/src/roles/kafka_broker/templates/kafka.env.j2
@@ -1,0 +1,2 @@
+KAFKA_HEAP_OPTS="{{ kafka_broker_heap_opts }}"
+KAFKA_LOG_DIRS="{{ kafka_broker_data_dir }}"

--- a/src/roles/kafka_broker/templates/kafka.service.j2
+++ b/src/roles/kafka_broker/templates/kafka.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Apache Kafka Broker
+After=network.target
+
+[Service]
+Type=simple
+User={{ kafka_broker_user }}
+Group={{ kafka_broker_group }}
+EnvironmentFile=-/etc/default/kafka
+ExecStart={{ kafka_broker_home }}/bin/kafka-server-start.sh {{ kafka_broker_home }}/config/server.properties
+ExecStop={{ kafka_broker_home }}/bin/kafka-server-stop.sh
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/src/roles/kafka_broker/templates/server.properties.j2
+++ b/src/roles/kafka_broker/templates/server.properties.j2
@@ -1,0 +1,4 @@
+broker.id={{ kafka_broker_id | default('0') }}
+listeners={{ kafka_broker_listeners }}
+log.dirs={{ kafka_broker_data_dir }}
+zookeeper.connect={{ kafka_broker_zookeeper_connect }}


### PR DESCRIPTION
## Summary
- add `kafka_broker` role for installing Apache Kafka
- document usage in `docs/kafka-role.md`

## Testing
- `ansible-lint src/roles/kafka_broker`

------
https://chatgpt.com/codex/tasks/task_e_6844b93642b4832aadff06498d57a76e