### PR TITLE
Add Proxmox role

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ and playbooks are organized so they can be reused for different clients and envi
 - `ansible.cfg` – basic configuration pointing Ansible at the bundled roles
 - `requirements.yml` – collection dependencies required to run the playbooks
 - `docs/` – documentation files (for example `keycloak-role.md`,
-  `kubeadm-guide.md`, and `kong-oss-role.md`)
+  `kubeadm-guide.md`, `kong-oss-role.md`, and `proxmox-role.md`)
 - `group_vars/` – group variable files used by the top level playbooks
- - `playbooks/` – simple playbooks demonstrating role usage such as `keycloak.yml` and `kubeadm.yml`, and `kong.yml`
+ - `playbooks/` – simple playbooks demonstrating role usage such as `keycloak.yml`, `kubeadm.yml`, `kong.yml`, and `proxmox.yml`
 - `src/` – primary Ansible project
   - `ansible.cfg` – configuration for running playbooks in `src`
   - `requirements.yml` – additional role and collection dependencies

--- a/docs/proxmox-role.md
+++ b/docs/proxmox-role.md
@@ -1,0 +1,38 @@
+# Proxmox Role
+
+## Overview
+
+The **proxmox** role installs Proxmox VE and can optionally bootstrap a cluster. It is useful for both small dev environments and larger production setups. The role adds the Proxmox APT repository, installs the `proxmox-ve` package set, and can run `pvecm create` or `pvecm add` based on variables.
+
+## Supported Operating Systems/Platforms
+
+- Debian 11/12
+- Ubuntu 20.04/22.04
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `proxmox_repo_release` | `bookworm` | Debian release used for the repo |
+| `proxmox_repo_url` | `http://download.proxmox.com/debian/pve` | Repository base URL |
+| `proxmox_repo_key_url` | `https://download.proxmox.com/debian/proxmox-release-{{ proxmox_repo_release }}.gpg` | Repository GPG key |
+| `proxmox_packages` | `[proxmox-ve, open-iscsi]` | Package list to install |
+| `proxmox_cluster_enabled` | `false` | Enable cluster configuration |
+| `proxmox_cluster_master` | `false` | Whether this node creates the cluster |
+| `proxmox_cluster_name` | `pve-cluster` | Cluster name when creating |
+| `proxmox_cluster_address` | _undefined_ | Address of an existing node to join |
+
+## Example Playbook
+
+```yaml
+- hosts: proxmox
+  become: true
+  vars:
+    proxmox_cluster_enabled: true
+    proxmox_cluster_master: false
+    proxmox_cluster_address: 10.0.0.1
+  roles:
+    - proxmox
+```
+
+In the example above, the host joins an existing cluster at `10.0.0.1`. Set `proxmox_cluster_master: true` on the first node to initialize the cluster instead.

--- a/group_vars/proxmox.yml
+++ b/group_vars/proxmox.yml
@@ -1,0 +1,5 @@
+---
+proxmox_cluster_enabled: true
+proxmox_cluster_master: true
+proxmox_cluster_name: pve
+# proxmox_cluster_address: 10.0.0.1

--- a/playbooks/proxmox.yml
+++ b/playbooks/proxmox.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure Proxmox hosts
+  hosts: proxmox
+  become: true
+  roles:
+    - proxmox

--- a/src/roles/proxmox/README.md
+++ b/src/roles/proxmox/README.md
@@ -1,0 +1,30 @@
+# Ansible Role: proxmox
+
+This role installs and configures **Proxmox VE** on Debian-based hosts. It adds the Proxmox APT repository, installs the `proxmox-ve` package group, and optionally creates or joins a Proxmox cluster.
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `proxmox_repo_release` | `bookworm` | Debian release for the repo |
+| `proxmox_repo_url` | `http://download.proxmox.com/debian/pve` | Repository base URL |
+| `proxmox_repo_key_url` | `https://download.proxmox.com/debian/proxmox-release-{{ proxmox_repo_release }}.gpg` | Repository GPG key |
+| `proxmox_packages` | `[proxmox-ve, open-iscsi]` | Packages to install |
+| `proxmox_cluster_enabled` | `false` | Whether to configure clustering |
+| `proxmox_cluster_master` | `false` | Set to true on the first node |
+| `proxmox_cluster_name` | `pve-cluster` | Cluster name when creating |
+| `proxmox_cluster_address` | _undefined_ | IP of existing cluster to join |
+
+## Example Playbook
+
+```yaml
+- hosts: proxmox
+  become: true
+  vars:
+    proxmox_cluster_enabled: true
+    proxmox_cluster_master: true
+  roles:
+    - proxmox
+```
+
+When `proxmox_cluster_enabled` is true, the first node (with `proxmox_cluster_master: true`) will run `pvecm create` to create the cluster. Additional nodes should set `proxmox_cluster_master: false` and provide `proxmox_cluster_address` of an existing member to join.

--- a/src/roles/proxmox/defaults/main.yml
+++ b/src/roles/proxmox/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+proxmox_repo_release: bookworm
+proxmox_repo_url: "http://download.proxmox.com/debian/pve"
+proxmox_repo_key_url: "https://download.proxmox.com/debian/proxmox-release-{{ proxmox_repo_release }}.gpg"
+proxmox_packages:
+  - proxmox-ve
+  - open-iscsi
+proxmox_cluster_enabled: false
+proxmox_cluster_master: false
+proxmox_cluster_name: "pve-cluster"
+# proxmox_cluster_address: "10.0.0.1"  # set when joining existing cluster

--- a/src/roles/proxmox/tasks/main.yml
+++ b/src/roles/proxmox/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+- name: Ensure Proxmox apt dependencies are present
+  ansible.builtin.apt:
+    name:
+      - gnupg
+      - curl
+    state: present
+    update_cache: true
+
+- name: Add Proxmox repository key
+  ansible.builtin.apt_key:
+    url: "{{ proxmox_repo_key_url }}"
+    state: present
+
+- name: Add Proxmox repository
+  ansible.builtin.apt_repository:
+    repo: "deb {{ proxmox_repo_url }} {{ proxmox_repo_release }} pve-no-subscription"
+    filename: proxmox
+    state: present
+
+- name: Install Proxmox packages
+  ansible.builtin.apt:
+    name: "{{ proxmox_packages }}"
+    state: present
+    update_cache: true
+
+- name: Create Proxmox cluster
+  ansible.builtin.command: >
+    pvecm create {{ proxmox_cluster_name }}
+  args:
+    creates: /etc/pve/corosync.conf
+  when:
+    - proxmox_cluster_enabled
+    - proxmox_cluster_master
+
+- name: Join Proxmox cluster
+  ansible.builtin.command: >
+    pvecm add {{ proxmox_cluster_address }}
+  args:
+    creates: /etc/pve/corosync.conf
+  when:
+    - proxmox_cluster_enabled
+    - not proxmox_cluster_master
+    - proxmox_cluster_address is defined


### PR DESCRIPTION
## Summary
- add Proxmox role for installing and clustering Proxmox VE
- include example playbook and defaults
- document role variables
- add group vars placeholder
- mention documentation and playbook in root README

## Testing
- `ansible-lint -v` *(fails: 204 failure(s), 3 warning(s))*

------
https://chatgpt.com/codex/tasks/task_e_6844bc0f0cdc832ab84030d91b206237