### PR TITLE
Add pfSense role

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ and playbooks are organized so they can be reused for different clients and envi
 ## Repository Layout
 - `ansible.cfg` – basic configuration pointing Ansible at the bundled roles
 - `requirements.yml` – collection dependencies required to run the playbooks
-- `docs/` – documentation files (for example `keycloak-role.md`,
-  `kubeadm-guide.md`, and `kong-oss-role.md`)
-- `group_vars/` – group variable files used by the top level playbooks
- - `playbooks/` – simple playbooks demonstrating role usage such as `keycloak.yml` and `kubeadm.yml`, and `kong.yml`
+ - `docs/` – documentation files (for example `keycloak-role.md`,
+   `kubeadm-guide.md`, `kong-oss-role.md`, and `pfsense-role.md`)
+ - `group_vars/` – group variable files used by the top level playbooks
+  - `playbooks/` – simple playbooks demonstrating role usage such as `keycloak.yml`, `kubeadm.yml`, `kong.yml`, and `pfsense.yml`
 - `src/` – primary Ansible project
   - `ansible.cfg` – configuration for running playbooks in `src`
   - `requirements.yml` – additional role and collection dependencies

--- a/docs/pfsense-role.md
+++ b/docs/pfsense-role.md
@@ -1,0 +1,37 @@
+# pfSense Role
+
+## Overview
+
+The **pfsense** role provides a simple framework for managing pfSense firewall
+configuration via Ansible. It uses modules from the `pfsensible.core` collection
+to configure interfaces, gateways, aliases and firewall rules. The role assumes
+pfSense is already installed and reachable over SSH.
+
+## Supported Platforms
+
+- pfSense CE 2.7+
+- pfSense Plus 23.09+
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `pfsense_interfaces` | `[]` | List of interface mappings (name, ip, mask, description) |
+| `pfsense_gateways` | `[]` | List of gateway definitions |
+| `pfsense_default_gateway` | `''` | Name of the default gateway to set |
+| `pfsense_aliases` | `[]` | Firewall alias entries |
+| `pfsense_rules` | `[]` | Firewall rule definitions |
+| `pfsense_enable_ssh` | `true` | Enable SSH access on pfSense |
+
+## Example Playbook
+
+```yaml
+- hosts: pfsense_firewalls
+  gather_facts: false
+  roles:
+    - pfsense
+```
+
+Firewall rules and other settings should be provided via variables as shown in
+the role README. Secrets like admin passwords should be stored with **Ansible
+Vault**.

--- a/playbooks/pfsense.yml
+++ b/playbooks/pfsense.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure pfSense firewall
+  hosts: pfsense_firewalls
+  gather_facts: false
+  roles:
+    - pfsense

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,3 +4,5 @@ collections:
     version: ">=3.4.0"
   - name: community.general
     version: ">=8.4.0"
+  - name: pfsensible.core
+    version: ">=1.4.0"

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -14,3 +14,5 @@ collections:
     version: ">=2.0.0"
   - name: community.postgresql
     version: ">=2.5.0"
+  - name: pfsensible.core
+    version: ">=1.4.0"

--- a/src/roles/pfsense/README.md
+++ b/src/roles/pfsense/README.md
@@ -1,0 +1,57 @@
+# Ansible Role: pfSense
+
+## Overview
+
+This role manages pfSense firewall configuration using the
+[pfsensible.core](https://github.com/pfsensible/core) collection. It assumes a
+running pfSense instance with SSH access and Python available. The role can
+configure interfaces, gateways, aliases and firewall rules so that pfSense can
+be managed as code.
+
+## Supported Platforms
+
+* pfSense CE 2.7+
+* pfSense Plus 23.09+
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `pfsense_interfaces` | `[]` | List of interface definitions (name, ip, mask, description) |
+| `pfsense_gateways` | `[]` | List of gateway objects (name, interface, gateway, description) |
+| `pfsense_default_gateway` | `''` | Name of the gateway to set as default |
+| `pfsense_aliases` | `[]` | List of alias objects to create |
+| `pfsense_rules` | `[]` | List of firewall rule dictionaries |
+| `pfsense_enable_ssh` | `true` | Whether to enable SSH on pfSense |
+
+## Example Playbook
+
+```yaml
+- hosts: pfsense_firewalls
+  gather_facts: false
+  roles:
+    - role: pfsense
+      vars:
+        pfsense_interfaces:
+          - name: LAN
+            ip: 10.0.0.1
+            mask: 24
+        pfsense_aliases:
+          - name: WEB_SERVERS
+            type: host
+            addresses:
+              - 10.0.0.10
+              - 10.0.0.11
+        pfsense_rules:
+          - interface: LAN
+            action: pass
+            protocol: tcp
+            source: any
+            destination: alias:WEB_SERVERS
+            destination_port: 443
+            description: Allow HTTPS to web servers
+```
+
+This role requires the `pfsensible.core` collection which is included in the
+repository `requirements.yml` files. SSH keys or passwords should be managed with
+Ansible Vault.

--- a/src/roles/pfsense/defaults/main.yml
+++ b/src/roles/pfsense/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# pfSense role defaults
+pfsense_interfaces: []
+pfsense_gateways: []
+pfsense_default_gateway: ''
+pfsense_aliases: []
+pfsense_rules: []
+pfsense_enable_ssh: true

--- a/src/roles/pfsense/meta/main.yml
+++ b/src/roles/pfsense/meta/main.yml
@@ -1,0 +1,11 @@
+---
+galaxy_info:
+  author: Example Inc.
+  description: Manage pfSense firewall configuration
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: FreeBSD
+      versions:
+        - "13"
+dependencies: []

--- a/src/roles/pfsense/tasks/main.yml
+++ b/src/roles/pfsense/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+- name: Enable SSH
+  ansible.builtin.shell: |
+    pfSsh.php playback svc enable ssh
+  when: pfsense_enable_ssh | bool
+
+- name: Configure interfaces
+  pfsensible.core.pfsense_interface:
+    interface: "{{ item.name }}"
+    ip_address: "{{ item.ip }}"
+    subnet: "{{ item.mask }}"
+    description: "{{ item.description | default('') }}"
+  loop: "{{ pfsense_interfaces }}"
+
+- name: Configure gateways
+  pfsensible.core.pfsense_gateway:
+    name: "{{ item.name }}"
+    interface: "{{ item.interface }}"
+    gateway: "{{ item.gateway }}"
+    description: "{{ item.description | default('') }}"
+  loop: "{{ pfsense_gateways }}"
+
+- name: Set default gateway
+  pfsensible.core.pfsense_default_gateway:
+    name: "{{ pfsense_default_gateway }}"
+  when: pfsense_default_gateway != ''
+
+- name: Configure aliases
+  pfsensible.core.pfsense_alias:
+    name: "{{ item.name }}"
+    type: "{{ item.type }}"
+    address: "{{ item.addresses }}"
+    description: "{{ item.description | default('') }}"
+  loop: "{{ pfsense_aliases }}"
+
+- name: Configure firewall rules
+  pfsensible.core.pfsense_rule:
+    interface: "{{ item.interface }}"
+    action: "{{ item.action }}"
+    protocol: "{{ item.protocol | default('any') }}"
+    source: "{{ item.source | default('any') }}"
+    destination: "{{ item.destination | default('any') }}"
+    destination_port: "{{ item.destination_port | default('') }}"
+    description: "{{ item.description | default('') }}"
+  loop: "{{ pfsense_rules }}"


### PR DESCRIPTION
## Summary
- add pfSense role for managing interfaces, gateways, aliases and rules
- document role usage in `docs/pfsense-role.md`
- include new playbook `playbooks/pfsense.yml`
- add collection dependency `pfsensible.core`
- reference new docs and playbook in main `README.md`

## Testing
- `git commit -m "Add pfSense role"`

------
https://chatgpt.com/codex/tasks/task_e_6844bd38c030832ab3431c525265ac41