### PR TITLE
Add Rocket.Chat role

### DIFF
--- a/docs/rocket-chat-role.md
+++ b/docs/rocket-chat-role.md
@@ -1,0 +1,22 @@
+# Rocket.Chat Role
+
+This document describes the `rocket_chat` Ansible role which deploys a
+single-instance Rocket.Chat server on Debian hosts. The role installs
+Node.js, downloads a specified Rocket.Chat release, and configures the
+application as a systemd service. It is suitable for development or small
+installations. For production clustering, extend the inventory and MongoDB
+configuration accordingly.
+
+## Usage
+
+Add hosts to the `rocketchat` group and apply the role:
+
+```yaml
+- hosts: rocketchat
+  become: true
+  roles:
+    - rocket_chat
+```
+
+Customize variables such as `rocket_chat_version`, `rocket_chat_mongo_url`,
+and `rocket_chat_root_url` via inventory or extra vars.

--- a/group_vars/rocketchat.yml
+++ b/group_vars/rocketchat.yml
@@ -1,0 +1,3 @@
+---
+rocket_chat_mongo_url: "mongodb://mongo1:27017/rocketchat?replicaSet=rs01"
+rocket_chat_root_url: "https://chat.example.com"

--- a/playbooks/rocketchat.yml
+++ b/playbooks/rocketchat.yml
@@ -1,0 +1,6 @@
+---
+- name: Deploy Rocket.Chat
+  hosts: rocketchat
+  become: true
+  roles:
+    - rocket_chat

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,3 +1,6 @@
 ---
 - name: Include keycloak playbook
   import_playbook: keycloak.yml
+- name: Include Rocket.Chat playbook
+  import_playbook: rocketchat.yml
+

--- a/src/roles/rocket_chat/README.md
+++ b/src/roles/rocket_chat/README.md
@@ -1,0 +1,27 @@
+# rocket_chat Ansible Role
+
+## Overview
+
+This role installs the Rocket.Chat messaging server on Debian-based systems.
+It downloads a specific Rocket.Chat release, installs required Node.js
+packages, and sets up a systemd service to manage the application.
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `rocket_chat_version` | `"6.13.0"` | Rocket.Chat version to install |
+| `rocket_chat_install_dir` | `/opt/Rocket.Chat` | Installation directory |
+| `rocket_chat_user` | `rocketchat` | System user running the service |
+| `rocket_chat_port` | `3000` | Service listening port |
+| `rocket_chat_mongo_url` | `mongodb://localhost:27017/rocketchat` | MongoDB connection string |
+| `rocket_chat_root_url` | `http://localhost:3000` | Public URL of the service |
+
+## Example Playbook
+
+```yaml
+- hosts: rocketchat
+  become: true
+  roles:
+    - rocket_chat
+```

--- a/src/roles/rocket_chat/defaults/main.yml
+++ b/src/roles/rocket_chat/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+rocket_chat_version: "6.13.0"
+rocket_chat_install_dir: "/opt/Rocket.Chat"
+rocket_chat_user: "rocketchat"
+rocket_chat_port: 3000
+rocket_chat_mongo_url: "mongodb://localhost:27017/rocketchat"
+rocket_chat_root_url: "http://localhost:3000"

--- a/src/roles/rocket_chat/handlers/main.yml
+++ b/src/roles/rocket_chat/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/src/roles/rocket_chat/tasks/main.yml
+++ b/src/roles/rocket_chat/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+- name: Install dependencies
+  ansible.builtin.apt:
+    name:
+      - curl
+      - ca-certificates
+      - gnupg
+      - build-essential
+      - nodejs
+    state: present
+    update_cache: true
+
+- name: Ensure rocket chat user
+  ansible.builtin.user:
+    name: "{{ rocket_chat_user }}"
+    system: true
+    home: "{{ rocket_chat_install_dir }}"
+    shell: /usr/sbin/nologin
+
+- name: Create install directory
+  ansible.builtin.file:
+    path: "{{ rocket_chat_install_dir }}"
+    state: directory
+    owner: "{{ rocket_chat_user }}"
+    group: "{{ rocket_chat_user }}"
+    mode: '0755'
+
+- name: Download Rocket.Chat archive
+  ansible.builtin.get_url:
+    url: "https://releases.rocket.chat/{{ rocket_chat_version }}/download"
+    dest: "/tmp/rocket.chat.tgz"
+    mode: '0644'
+    force: true
+
+- name: Extract Rocket.Chat
+  ansible.builtin.unarchive:
+    src: "/tmp/rocket.chat.tgz"
+    dest: "{{ rocket_chat_install_dir }}"
+    remote_src: true
+    creates: "{{ rocket_chat_install_dir }}/main.js"
+    owner: "{{ rocket_chat_user }}"
+    group: "{{ rocket_chat_user }}"
+
+- name: Install Node dependencies
+  become: true
+  ansible.builtin.command: npm install
+  args:
+    chdir: "{{ rocket_chat_install_dir }}/programs/server"
+    creates: "{{ rocket_chat_install_dir }}/programs/server/node_modules"
+  become_user: "{{ rocket_chat_user }}"
+
+- name: Deploy systemd unit
+  ansible.builtin.template:
+    src: rocketchat.service.j2
+    dest: /etc/systemd/system/rocketchat.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Reload systemd
+
+- name: Ensure Rocket.Chat service enabled and started
+  ansible.builtin.systemd:
+    name: rocketchat
+    enabled: true
+    state: started

--- a/src/roles/rocket_chat/templates/rocketchat.service.j2
+++ b/src/roles/rocket_chat/templates/rocketchat.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Rocket.Chat server
+After=network.target
+
+[Service]
+Type=simple
+User={{ rocket_chat_user }}
+Group={{ rocket_chat_user }}
+ExecStart=/usr/bin/node {{ rocket_chat_install_dir }}/main.js
+Environment=ROOT_URL={{ rocket_chat_root_url }}
+Environment=MONGO_URL={{ rocket_chat_mongo_url }}
+Environment=PORT={{ rocket_chat_port }}
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add rocket_chat role for single-node Rocket.Chat service
- wire role into example playbooks and group vars
- document role usage

## Testing
- `ansible-lint src/roles/rocket_chat`

------
https://chatgpt.com/codex/tasks/task_e_6844bfe88504832a98e52cbb00eda61c