### PR TITLE
Add Nexus role

### DIFF
--- a/docs/nexus-role.md
+++ b/docs/nexus-role.md
@@ -1,0 +1,16 @@
+# Nexus Repository Manager Role
+
+This role installs and configures Sonatype Nexus Repository Manager on Debian hosts. It follows the best practices outlined in the implementation guide for idempotent tasks and modular design.
+
+## Usage
+
+Add hosts to the `nexus` group and apply the role:
+
+```yaml
+- hosts: nexus
+  become: true
+  roles:
+    - nexus
+```
+
+Customize variables such as `nexus_version`, `nexus_port`, and JVM options via inventory or extra vars.

--- a/src/roles/nexus/README.md
+++ b/src/roles/nexus/README.md
@@ -1,0 +1,28 @@
+# nexus Ansible Role
+
+This role installs Sonatype Nexus Repository Manager on Debian-based systems. It downloads a specified Nexus release, configures basic settings, and sets up a systemd service.
+
+## Role Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `nexus_version` | `"3.56.0-02"` | Nexus version to install |
+| `nexus_download_url` | `https://download.sonatype.com/nexus/3/nexus-{{ nexus_version }}-unix.tar.gz` | URL of the archive |
+| `nexus_user` | `nexus` | System user running the service |
+| `nexus_group` | `nexus` | Group for the service |
+| `nexus_home` | `/opt/nexus` | Installation directory |
+| `nexus_data_dir` | `/opt/sonatype-work` | Data directory |
+| `nexus_java_package` | `openjdk-11-jdk` | Java package to install |
+| `nexus_port` | `8081` | HTTP port |
+| `nexus_min_heap` | `1200m` | JVM minimum heap |
+| `nexus_max_heap` | `1200m` | JVM maximum heap |
+| `nexus_active_processors` | `2` | JVM processors hint |
+
+## Example Playbook
+
+```yaml
+- hosts: nexus
+  become: true
+  roles:
+    - nexus
+```

--- a/src/roles/nexus/defaults/main.yml
+++ b/src/roles/nexus/defaults/main.yml
@@ -1,0 +1,11 @@
+nexus_version: "3.56.0-02"
+nexus_user: "nexus"
+nexus_group: "nexus"
+nexus_home: "/opt/nexus"
+nexus_data_dir: "/opt/sonatype-work"
+nexus_java_package: "openjdk-11-jdk"
+nexus_download_url: "https://download.sonatype.com/nexus/3/nexus-{{ nexus_version }}-unix.tar.gz"
+nexus_port: 8081
+nexus_min_heap: "1200m"
+nexus_max_heap: "1200m"
+nexus_active_processors: 2

--- a/src/roles/nexus/handlers/main.yml
+++ b/src/roles/nexus/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true
+
+- name: Restart Nexus
+  ansible.builtin.systemd:
+    name: nexus
+    state: restarted
+  become: true

--- a/src/roles/nexus/molecule/default/converge.yml
+++ b/src/roles/nexus/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  roles:
+    - role: nexus

--- a/src/roles/nexus/molecule/default/molecule.yml
+++ b/src/roles/nexus/molecule/default/molecule.yml
@@ -1,0 +1,15 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: nexus
+    image: debian:12
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+verifier:
+  name: testinfra

--- a/src/roles/nexus/molecule/default/tests/test_nexus.py
+++ b/src/roles/nexus/molecule/default/tests/test_nexus.py
@@ -1,0 +1,18 @@
+import os
+import testinfra.utils.ansible_runner
+
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_user_exists(host):
+    user = host.user('nexus')
+    assert user.exists
+
+
+def test_service_running(host):
+    svc = host.service('nexus')
+    assert svc.is_enabled
+    assert svc.is_running

--- a/src/roles/nexus/tasks/config.yml
+++ b/src/roles/nexus/tasks/config.yml
@@ -1,0 +1,30 @@
+---
+- name: Deploy nexus.vmoptions
+  ansible.builtin.template:
+    src: nexus.vmoptions.j2
+    dest: "{{ nexus_home }}/current/bin/nexus.vmoptions"
+    owner: "{{ nexus_user }}"
+    group: "{{ nexus_group }}"
+    mode: "0644"
+  notify: Restart Nexus
+  become: true
+
+- name: Deploy nexus.properties
+  ansible.builtin.template:
+    src: nexus.properties.j2
+    dest: "{{ nexus_home }}/current/etc/nexus.properties"
+    owner: "{{ nexus_user }}"
+    group: "{{ nexus_group }}"
+    mode: "0644"
+  notify: Restart Nexus
+  become: true
+
+- name: Deploy systemd unit
+  ansible.builtin.template:
+    src: nexus.service.j2
+    dest: /etc/systemd/system/nexus.service
+    mode: "0644"
+  notify:
+    - Reload systemd
+    - Restart Nexus
+  become: true

--- a/src/roles/nexus/tasks/install.yml
+++ b/src/roles/nexus/tasks/install.yml
@@ -1,0 +1,66 @@
+---
+- name: Install Java runtime
+  ansible.builtin.apt:
+    name: "{{ nexus_java_package }}"
+    state: present
+    update_cache: true
+  become: true
+
+- name: Create nexus group
+  ansible.builtin.group:
+    name: "{{ nexus_group }}"
+    system: true
+  become: true
+
+- name: Create nexus user
+  ansible.builtin.user:
+    name: "{{ nexus_user }}"
+    group: "{{ nexus_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+  become: true
+
+- name: Create installation directory
+  ansible.builtin.file:
+    path: "{{ nexus_home }}"
+    state: directory
+    owner: "{{ nexus_user }}"
+    group: "{{ nexus_group }}"
+    mode: "0755"
+  become: true
+
+- name: Create data directory
+  ansible.builtin.file:
+    path: "{{ nexus_data_dir }}"
+    state: directory
+    owner: "{{ nexus_user }}"
+    group: "{{ nexus_group }}"
+    mode: "0755"
+  become: true
+
+- name: Download Nexus archive
+  ansible.builtin.get_url:
+    url: "{{ nexus_download_url }}"
+    dest: "/tmp/nexus-{{ nexus_version }}-unix.tar.gz"
+    mode: "0644"
+    force: false
+  become: true
+
+- name: Extract Nexus
+  ansible.builtin.unarchive:
+    src: "/tmp/nexus-{{ nexus_version }}-unix.tar.gz"
+    dest: "{{ nexus_home }}"
+    remote_src: true
+    creates: "{{ nexus_home }}/nexus-{{ nexus_version }}/bin/nexus"
+    owner: "{{ nexus_user }}"
+    group: "{{ nexus_group }}"
+  become: true
+
+- name: Set current symlink
+  ansible.builtin.file:
+    src: "{{ nexus_home }}/nexus-{{ nexus_version }}"
+    dest: "{{ nexus_home }}/current"
+    state: link
+    owner: "{{ nexus_user }}"
+    group: "{{ nexus_group }}"
+  become: true

--- a/src/roles/nexus/tasks/main.yml
+++ b/src/roles/nexus/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- ansible.builtin.import_tasks: install.yml
+- ansible.builtin.import_tasks: config.yml
+- ansible.builtin.import_tasks: service.yml
+

--- a/src/roles/nexus/tasks/service.yml
+++ b/src/roles/nexus/tasks/service.yml
@@ -1,0 +1,7 @@
+---
+- name: Ensure Nexus service enabled and started
+  ansible.builtin.systemd:
+    name: nexus
+    enabled: true
+    state: started
+  become: true

--- a/src/roles/nexus/templates/nexus.properties.j2
+++ b/src/roles/nexus/templates/nexus.properties.j2
@@ -1,0 +1,4 @@
+# Sonatype Nexus configuration
+application-port={{ nexus_port }}
+nexus-context-path=/
+nexus-data={{ nexus_data_dir }}

--- a/src/roles/nexus/templates/nexus.service.j2
+++ b/src/roles/nexus/templates/nexus.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Sonatype Nexus Repository Manager
+After=network.target
+
+[Service]
+Type=forking
+User={{ nexus_user }}
+Group={{ nexus_group }}
+ExecStart={{ nexus_home }}/current/bin/nexus start
+ExecStop={{ nexus_home }}/current/bin/nexus stop
+Restart=on-failure
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/src/roles/nexus/templates/nexus.vmoptions.j2
+++ b/src/roles/nexus/templates/nexus.vmoptions.j2
@@ -1,0 +1,5 @@
+-Xms{{ nexus_min_heap }}
+-Xmx{{ nexus_max_heap }}
+-XX:+UnlockExperimentalVMOptions
+-XX:+UseCGroupMemoryLimitForHeap
+-XX:ActiveProcessorCount={{ nexus_active_processors }}


### PR DESCRIPTION
## Summary
- add Sonatype Nexus role with basic install/config/service tasks
- document role variables and example use
- include Molecule tests
- add docs entry about the Nexus role

## Testing
- `ansible-lint src/roles/nexus` *(fails: Unknown error when attempting to call Galaxy)*
- `molecule test -s default` *(fails: Failed to find driver docker)*

------
https://chatgpt.com/codex/tasks/task_e_6844c6e43610832aa6b441e3f302ca8d