### PR TITLE
Fix some ansible lint issues

### DIFF
--- a/src/databases/linux/roles/postgresql_client/molecule/default/converge.yml
+++ b/src/databases/linux/roles/postgresql_client/molecule/default/converge.yml
@@ -9,13 +9,13 @@
     keycloak_db_password: changeme
   tasks:
     - name: Install PostgreSQL server
-      apt:
+      ansible.builtin.apt:
         name: postgresql
         state: present
         update_cache: true
 
     - name: Ensure postgres is running
-      service:
+      ansible.builtin.service:
         name: postgresql
         state: started
         enabled: true

--- a/src/databases/linux/roles/postgresql_client/molecule/podman/converge.yml
+++ b/src/databases/linux/roles/postgresql_client/molecule/podman/converge.yml
@@ -9,13 +9,13 @@
     keycloak_db_password: changeme
   tasks:
     - name: Install PostgreSQL server
-      apt:
+      ansible.builtin.apt:
         name: postgresql
         state: present
         update_cache: true
 
     - name: Ensure postgres is running
-      service:
+      ansible.builtin.service:
         name: postgresql
         state: started
         enabled: true

--- a/src/roles/postgres_backup/molecule/default/converge.yml
+++ b/src/roles/postgres_backup/molecule/default/converge.yml
@@ -7,7 +7,7 @@
     db_user: postgres
   tasks:
     - name: Install PostgreSQL server
-      apt:
+      ansible.builtin.apt:
         name: postgresql
         state: present
         update_cache: true

--- a/src/roles/postgres_backup/molecule/podman/converge.yml
+++ b/src/roles/postgres_backup/molecule/podman/converge.yml
@@ -7,7 +7,7 @@
     db_user: postgres
   tasks:
     - name: Install PostgreSQL server
-      apt:
+      ansible.builtin.apt:
         name: postgresql
         state: present
         update_cache: true

--- a/src/roles/rabbitmq/tasks/cluster.yml
+++ b/src/roles/rabbitmq/tasks/cluster.yml
@@ -3,7 +3,7 @@
   ansible.builtin.command: "rabbitmqctl join_cluster rabbit@{{ rabbitmq_cluster_master_node }}"
   when: inventory_hostname != rabbitmq_cluster_master_node
   register: join_out
-  changed_when: "Clustering node" in join_out.stdout
+  changed_when: '"Clustering node" in join_out.stdout'
   notify: Restart RabbitMQ
 
 - name: Set HA policy on master


### PR DESCRIPTION
## Summary
- fix invalid quoting in rabbitmq clustering task
- use FQCN for apt/service tasks in molecule converge steps

## Testing
- `ansible-lint --offline` *(fails: 223 failure(s), 3 warning(s))*

------
https://chatgpt.com/codex/tasks/task_e_684e0a384060832ab7cd2a4167cfaa5f