### PR TITLE
Reinstate Galaxy dependencies in base role

### DIFF
--- a/src/infrastructure/linux/roles/base/defaults/main.yml
+++ b/src/infrastructure/linux/roles/base/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+base_enable_bootstrap: true
+base_enable_auto_update: true
+base_enable_fail2ban: true
+base_enable_clamav: true

--- a/src/infrastructure/linux/roles/base/meta/main.yml
+++ b/src/infrastructure/linux/roles/base/meta/main.yml
@@ -13,10 +13,14 @@ galaxy_info:
 dependencies:
   - role: remove_unnecessary_packages
   - role: update_system
-  # - role: robertdebock.bootstrap
+  - role: robertdebock.bootstrap
+    when: base_enable_bootstrap | bool
   # - role: willshersystems.sshd
-  # - role: robertdebock.auto_update
-  # - role: robertdebock.fail2ban
+  - role: robertdebock.auto_update
+    when: base_enable_auto_update | bool
+  - role: robertdebock.fail2ban
+    when: base_enable_fail2ban | bool
   # - role: oefenweb.ufw
-  # - role: geerlingguy.clamav
+  - role: geerlingguy.clamav
+    when: base_enable_clamav | bool
   # - role: configure_filebeat_os


### PR DESCRIPTION
## Summary
- re-enable the external Galaxy role dependencies within the base role meta configuration
- add defaults allowing each Galaxy dependency to be toggled on or off when needed

## Testing
- ansible-lint --offline src/infrastructure/linux/roles/base *(fails: missing Galaxy roles are not vendored in the offline environment)*
- molecule test *(fails: docker Molecule driver is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc345737f0832aa568c77f244cbb9a