### PR TITLE
Add security hardening roles to Ansible requirements

### DIFF
--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -6,6 +6,10 @@ roles:
     version: "1.7.0"
   - name: geerlingguy.java
     version: "2.3.0"
+  - name: robertdebock.bootstrap
+  - name: robertdebock.auto_update
+  - name: robertdebock.fail2ban
+  - name: geerlingguy.clamav
 
 collections:
   - name: community.hashi_vault


### PR DESCRIPTION
## Summary
- append security and maintenance galaxy roles to `src/requirements.yml`

## Testing
- `ansible-galaxy install -r src/requirements.yml --force` *(fails: Tunnel connection failed: 403 Forbidden)*
- `ansible-lint` *(fails: Tunnel connection failed: 403 Forbidden while refreshing collections)*

------
https://chatgpt.com/codex/tasks/task_e_68dc346b4944832aa2cacc164bc93fa5