### PR TITLE
Update ansible-playbook wrappers to use repo-relative defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ and playbooks are organized so they can be reused for different clients and envi
 - `ansible.cfg` – basic configuration pointing Ansible at the bundled roles
 - `requirements.yml` – collection dependencies required to run the playbooks
 - `bin/` – helper scripts for executing Ansible
+  - The `ansible-playbook` wrapper scripts now derive their default paths from the
+    repository location, so they work no matter where the repository is cloned.
+    Set environment variables (for the Bash script) or pass parameters/environment
+    variables (for the PowerShell script) to override any of the defaults when
+    needed.
 - `docs/` – documentation files (for example `keycloak-role.md`,
   `kubeadm-guide.md`, `kong-oss-role.md`, and `proxmox-role.md`)
 - `group_vars/` – group variable files used by the top level playbooks

--- a/bin/ansible-playbook.sh
+++ b/bin/ansible-playbook.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 
-# Set variables from environment or use default values
-WORK_DIR="${WORK_DIR:-${HOME}/dev/workspace/qimata}"
-ANSIBLE_WORK_DIR="${ANSIBLE_WORK_DIR:-${WORK_DIR}/qimata-ansible/ansible}"
+# Determine the repository root based on the script location so defaults work
+# regardless of where the repository is cloned.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set variables from environment or use default values relative to the repository
+# location. Users can still override any of these via environment variables when
+# invoking the script.
+WORK_DIR="${WORK_DIR:-${REPO_ROOT}}"
+ANSIBLE_WORK_DIR="${ANSIBLE_WORK_DIR:-${REPO_ROOT}}"
 SSH_PRIVATE_KEY="${SSH_PRIVATE_KEY:-ansible-dev_id_rsa}"
-SSH_KEY_DIR="${SSH_KEY_DIR:-${HOME}/dev/workspace/qimata/ssh/ansible}"
+SSH_KEY_DIR="${SSH_KEY_DIR:-${REPO_ROOT}/ssh/ansible}"
 REMOTE_USER="${REMOTE_USER:-ansible}"
-ANSIBLE_VAULT_DIR="${ANSIBLE_VAULT_DIR:-${WORK_DIR}/vault}"
+ANSIBLE_VAULT_DIR="${ANSIBLE_VAULT_DIR:-${REPO_ROOT}/vault}"
 ANSIBLE_VAULT_PASSWORD_FILE="${ANSIBLE_VAULT_PASSWORD_FILE:-vault_pass.txt}"
 ANSIBLE_HOST_KEY_CHECKING="${ANSIBLE_HOST_KEY_CHECKING:-False}"
 ANSIBLE_IMAGE="${ANSIBLE_IMAGE:-ansible:latest}"


### PR DESCRIPTION
## Summary
- derive the bash ansible-playbook wrapper defaults from the repository location while keeping environment overrides
- update the PowerShell wrapper to use PSScriptRoot-based defaults with matching environment overrides
- document the new wrapper behavior in the README

## Testing
- bash -n bin/ansible-playbook.sh

------
https://chatgpt.com/codex/tasks/task_e_68dc3601273c832a9169d11e30a6a564