### PR TITLE
Ensure create_ansible_inventory handles missing output directory

### DIFF
--- a/src/scripts/create_ansible_inventory.py
+++ b/src/scripts/create_ansible_inventory.py
@@ -82,6 +82,7 @@ def create_ansible_ini_file(db_conn_str, output_directory, ansible_user=None, be
         envs[env].add(cat)
 
     # Write to the ini file
+    os.makedirs(output_directory, exist_ok=True)
     for env, cat_set in envs.items():
         with open(os.path.join(output_directory, f'{env}.ini'), 'w') as configfile:
             configfile.write('[all:children]\n')


### PR DESCRIPTION
## Summary
- ensure `create_ansible_inventory.py` creates the requested output directory before writing inventory files

## Testing
- PYTHONPATH=. python src/scripts/create_ansible_inventory.py --db_conn_str dummy --output_directory tmp/test_inventory --ansible-user tester
- pytest *(fails: requires the `testinfra` dependency which is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3b78d2e0832a83e19771fb63ca6e