### PR TITLE
Fix Jenkins roles handler notification casing

### DIFF
--- a/src/ci_cd/linux/roles/jenkins_agent/tasks/main.yml
+++ b/src/ci_cd/linux/roles/jenkins_agent/tasks/main.yml
@@ -17,4 +17,4 @@
     user: "{{ jenkins_agent_user }}"
     key: "{{ jenkins_agent_ssh_public_key }}"
     state: present
-  notify: restart ssh
+  notify: Restart SSH

--- a/src/ci_cd/linux/roles/jenkins_controller/tasks/main.yml
+++ b/src/ci_cd/linux/roles/jenkins_controller/tasks/main.yml
@@ -27,14 +27,14 @@
       - "jenkins={{ jenkins_controller_version }}*"
     state: present
     update_cache: true
-  notify: restart jenkins
+  notify: Restart Jenkins
 
 - name: Disable setup wizard
   ansible.builtin.lineinfile:
     path: /etc/default/jenkins
     regexp: '^JENKINS_ARGS='
     line: 'JENKINS_ARGS="--webroot=/var/cache/$NAME/war --httpPort={{ jenkins_http_port }} -Djenkins.install.runSetupWizard=false {{ jenkins_java_opts }}"'
-  notify: restart jenkins
+  notify: Restart Jenkins
 
 - name: Deploy admin groovy init
   ansible.builtin.template:
@@ -43,7 +43,7 @@
     owner: jenkins
     group: jenkins
     mode: "0644"
-  notify: restart jenkins
+  notify: Restart Jenkins
 
 - name: Create plugins list
   ansible.builtin.template:
@@ -59,7 +59,7 @@
     --plugin-download-directory {{ jenkins_controller_home }}/plugins
   args:
     creates: "{{ jenkins_controller_home }}/plugins/{{ jenkins_controller_plugins[0] }}.jpi"
-  notify: restart jenkins
+  notify: Restart Jenkins
 
 - name: Ensure Jenkins service enabled and started
   ansible.builtin.service:


### PR DESCRIPTION
## Summary
- align the Jenkins agent authorized key task notify string with the handler name so SSH restarts when the key changes
- align Jenkins controller notify strings with the Restart Jenkins handler to ensure service restarts after package and config updates

## Testing
- molecule test -s default (jenkins_agent) *(fails: docker driver not installed in environment)*
- molecule test -s default (jenkins_controller) *(fails: docker driver not installed in environment)*
- ansible-lint src/ci_cd/linux/roles/jenkins_agent src/ci_cd/linux/roles/jenkins_controller *(fails: unable to reach galaxy.ansible.com due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3b8248b0832a8d4d4fa8ba532f2c