### PR TITLE
Fix become pass quoting in inventory generator

### DIFF
--- a/src/scripts/create_ansible_inventory.py
+++ b/src/scripts/create_ansible_inventory.py
@@ -1,6 +1,7 @@
 import psycopg2
 import argparse
 import os
+import shlex
 
 
 def create_ansible_inventory_server_string(env, cat, ss, app, cont, management_ip, service_ip, ansible_user=None, become_pass=None):
@@ -13,7 +14,7 @@ def create_ansible_inventory_server_string(env, cat, ss, app, cont, management_i
     if ansible_user:
         inventory_str += f' ansible_user={ansible_user}'
     if become_pass:
-        inventory_str += f' ansible_become_pass={ vault_ansible_become_pass_common }'
+        inventory_str += f" ansible_become_pass={shlex.quote(become_pass)}"
 
     return inventory_str
 

--- a/tests/test_create_ansible_inventory.py
+++ b/tests/test_create_ansible_inventory.py
@@ -1,0 +1,30 @@
+import pathlib
+import shlex
+import sys
+import types
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+if 'psycopg2' not in sys.modules:
+    sys.modules['psycopg2'] = types.ModuleType('psycopg2')
+
+from src.scripts.create_ansible_inventory import create_ansible_inventory_server_string
+
+
+def test_create_ansible_inventory_server_string_includes_become_pass():
+    inventory = create_ansible_inventory_server_string(
+        env="prod",
+        cat="web",
+        ss="frontend",
+        app="app",
+        cont="host1",
+        management_ip="10.0.0.1/24",
+        service_ip="10.0.1.1/24",
+        ansible_user="ansible",
+        become_pass="pa ss$word",
+    )
+
+    expected_fragment = f"ansible_become_pass={shlex.quote('pa ss$word')}"
+    assert expected_fragment in inventory


### PR DESCRIPTION
## Summary
- quote the provided become password when building inventory server lines
- add a pytest covering create_ansible_inventory_server_string with a become password

## Testing
- pytest tests/test_create_ansible_inventory.py

------
https://chatgpt.com/codex/tasks/task_e_68dd3b8a0a70832a8efdc09a132165bc