### PR TITLE
Resolve merge conflicts in requirements and Spark metadata

### DIFF
--- a/src/data_platform/linux/roles/apache_spark/meta/main.yml
+++ b/src/data_platform/linux/roles/apache_spark/meta/main.yml
@@ -1,11 +1,7 @@
 ---
 galaxy_info:
-<<<<<<<< HEAD:src/roles/data_analytics/spark_role/meta/main.yml
-  role_name: spark_role
-  namespace: data_analytics
-========
   role_name: apache_spark
->>>>>>>> Git/main:src/data_platform/linux/roles/apache_spark/meta/main.yml
+  namespace: example_inc
   author: Example Inc.
   description: Install and configure Apache Spark standalone cluster with optional HA on Debian
   license: MIT

--- a/src/group_vars/all.yml
+++ b/src/group_vars/all.yml
@@ -4,7 +4,6 @@ sshd:
   ListenAddress: "{{ hostvars[inventory_hostname]['ansible_host'] }}"
   PasswordAuthentication: true
 
-
 # install_fail2ban
 fail2ban_loglevel: INFO
 fail2ban_logtarget: /var/log/fail2ban.log
@@ -25,8 +24,7 @@ fail2ban_sender: admin@{{ ansible_fqdn }}
 auto_update_download_updates: true
 auto_update_apply_updates: false
 auto_update_random_sleep: 360
-<<<<<<< HEAD
-=======
+
 deployment_profile: "simple"
 ldap_data_file: "{{ playbook_dir }}/files/ldap_data.yml"
 ldap_replication: false
@@ -37,4 +35,3 @@ metadata_api_base: "http://10.0.0.20:5002"
 search_api_base: "http://10.0.0.21:5001"
 
 ansible_python_interpreter: /usr/bin/python3
->>>>>>> Git/main

--- a/src/playbooks/base.yml
+++ b/src/playbooks/base.yml
@@ -14,14 +14,8 @@
   hosts: "{{ base_target_group | default('all') }}"
   become: true
   vars_files:
-<<<<<<< HEAD
-    - group_vars/all.yml
-    - group_vars/systems_admin/shared_tools/ansible_semaphore/all.yml
-    - group_vars/systems_admin/shared_tools/ansible_semaphore/mariadb_galera.yml
-=======
     - "{{ playbook_dir }}/../group_vars/all.yml"
     - "{{ playbook_dir }}/../group_vars/systems_admin/shared_tools/ansible_semaphore/all.yml"
     - "{{ playbook_dir }}/../group_vars/systems_admin/shared_tools/ansible_semaphore/mariadb_galera.yml"
->>>>>>> Git/main
   roles:
     - base

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -1,8 +1,6 @@
 ---
-<<<<<<< HEAD
 # Minimal requirements for Molecule Proxmox testing
 # This file avoids dependency conflicts during testing
-=======
 roles:
   - name: geerlingguy.postgresql
     version: "3.3.0"
@@ -14,7 +12,6 @@ roles:
   - name: robertdebock.auto_update
   - name: robertdebock.fail2ban
   - name: geerlingguy.clamav
->>>>>>> Git/main
 
 collections:
   - name: community.general
@@ -25,16 +22,9 @@ collections:
     version: ">=1.0.0"
   - name: community.crypto
     version: ">=2.0.0"
-<<<<<<< HEAD
   - name: community.docker
     version: ">=3.10.0"
-
-roles:
-  - name: geerlingguy.java
-    version: ">=1.10.0"
-=======
   - name: community.postgresql
     version: ">=2.5.0"
   - name: pfsensible.core
     version: ">=1.4.0"
->>>>>>> Git/main

--- a/src/roles/data_analytics/spark_role/meta/main.yml
+++ b/src/roles/data_analytics/spark_role/meta/main.yml
@@ -1,11 +1,7 @@
 ---
 galaxy_info:
-<<<<<<<< HEAD:src/roles/data_analytics/spark_role/meta/main.yml
   role_name: spark_role
   namespace: data_analytics
-========
-  role_name: apache_spark
->>>>>>>> Git/main:src/data_platform/linux/roles/apache_spark/meta/main.yml
   author: Example Inc.
   description: Install and configure Apache Spark standalone cluster with optional HA on Debian
   license: MIT


### PR DESCRIPTION
## Summary
- merge the conflicting requirements to retain intended roles and collections
- restore shared group variables and base playbook var references after conflict resolution
- normalize Apache Spark role metadata with the correct Galaxy namespace information

## Testing
- `ansible-playbook src/playbooks/base.yml --syntax-check` *(fails: missing required Galaxy role `robertdebock.bootstrap` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dda180b040832a991bdf6702004d94