### PR TITLE
Fix ansible-lint findings for keycloak and postgres roles

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 inventory = ./src/inventory
-roles_path = ./src/security/linux/roles:./src/communication/linux/roles:./src/roles:./src/roles/networking:./src/roles/data_systems:./src/roles/data_systems/elasticsearch:./src/roles/data_systems/postgresql:./src/roles/data_systems/mariadb:./src/roles/data_analytics:./src/roles/data_analytics/amundsen:./src/roles/data_analytics/airflow:./src/roles/monitoring_observability:./src/roles/devops_cicd/jenkins:./src/roles/load_balancing_ha:./src/roles/infrastructure/shared:./src/roles/infrastructure:./src/infrastructure/linux/roles:~/.ansible/roles:/usr/share/ansible/roles
+roles_path = ./src/security/linux/roles:./src/communication/linux/roles:./src/identity/linux/roles:./src/roles:./src/roles/networking:./src/roles/data_systems:./src/roles/data_systems/elasticsearch:./src/roles/data_systems/postgresql:./src/roles/data_systems/mariadb:./src/roles/data_analytics:./src/roles/data_analytics/amundsen:./src/roles/data_analytics/airflow:./src/roles/monitoring_observability:./src/roles/devops_cicd/jenkins:./src/roles/load_balancing_ha:./src/roles/infrastructure/shared:./src/roles/infrastructure:./src/infrastructure/linux/roles:~/.ansible/roles:/usr/share/ansible/roles
 collections_paths = ./src/collections:~/.ansible/collections:/usr/share/ansible/collections
 interpreter_python = auto_silent
 host_key_checking = False

--- a/src/databases/linux/roles/postgres_backup/molecule/default/converge.yml
+++ b/src/databases/linux/roles/postgres_backup/molecule/default/converge.yml
@@ -13,8 +13,8 @@
         update_cache: true
 
     - name: Ensure database exists
-      become_user: postgres
       become: true
+      become_user: postgres
       community.postgresql.postgresql_db:
         name: "{{ postgres_backup_db_name }}"
       failed_when: false

--- a/src/databases/linux/roles/postgres_backup/molecule/podman/converge.yml
+++ b/src/databases/linux/roles/postgres_backup/molecule/podman/converge.yml
@@ -13,8 +13,8 @@
         update_cache: true
 
     - name: Ensure database exists
-      become_user: postgres
       become: true
+      become_user: postgres
       community.postgresql.postgresql_db:
         name: "{{ postgres_backup_db_name }}"
       failed_when: false

--- a/src/identity/linux/roles/keycloak/molecule/default/converge.yml
+++ b/src/identity/linux/roles/keycloak/molecule/default/converge.yml
@@ -16,18 +16,17 @@
         enabled: true
 
     - name: Create database
-      become_user: postgres
       become: true
+      become_user: postgres
       community.postgresql.postgresql_db:
         name: keycloak
 
     - name: Create user
-      become_user: postgres
       become: true
+      become_user: postgres
       community.postgresql.postgresql_user:
         name: keycloak
         password: keycloak
-        priv: ALL
   roles:
     - role: keycloak
       vars:

--- a/src/identity/linux/roles/keycloak/molecule/podman/converge.yml
+++ b/src/identity/linux/roles/keycloak/molecule/podman/converge.yml
@@ -27,7 +27,6 @@
       community.postgresql.postgresql_user:
         name: keycloak
         password: keycloak
-        priv: ALL
   roles:
     - role: keycloak
       vars:

--- a/src/identity/linux/roles/keycloak_realm/molecule/default/converge.yml
+++ b/src/identity/linux/roles/keycloak_realm/molecule/default/converge.yml
@@ -27,7 +27,6 @@
       community.postgresql.postgresql_user:
         name: keycloak
         password: keycloak
-        priv: ALL
 
   roles:
     - role: keycloak

--- a/src/identity/linux/roles/keycloak_realm/molecule/podman/converge.yml
+++ b/src/identity/linux/roles/keycloak_realm/molecule/podman/converge.yml
@@ -27,7 +27,6 @@
       community.postgresql.postgresql_user:
         name: keycloak
         password: keycloak
-        priv: ALL
 
   roles:
     - role: keycloak

--- a/src/infrastructure/linux/roles/backup_netbox/tasks/main.yml
+++ b/src/infrastructure/linux/roles/backup_netbox/tasks/main.yml
@@ -14,8 +14,8 @@
     login_host: "{{ postgres_host }}"
     login_user: "{{ postgres_user }}"
     login_password: "{{ postgres_password }}"
-  become_user: postgres
   become: true
+  become_user: postgres
 
 - name: Archive NetBox media
   community.general.archive:

--- a/src/roles/data_systems/postgresql/postgres_backup/molecule/default/converge.yml
+++ b/src/roles/data_systems/postgresql/postgres_backup/molecule/default/converge.yml
@@ -13,11 +13,11 @@
         update_cache: true
 
     - name: Ensure database exists
+      become: true
       become_user: postgres
       community.postgresql.postgresql_db:
         name: "{{ db_name }}"
       failed_when: false
-      become: true
 
     - name: Apply postgres_backup role  # noqa role-name[path]
       ansible.builtin.import_role:

--- a/src/roles/data_systems/postgresql/postgres_backup/molecule/podman/converge.yml
+++ b/src/roles/data_systems/postgresql/postgres_backup/molecule/podman/converge.yml
@@ -13,11 +13,11 @@
         update_cache: true
 
     - name: Ensure database exists
+      become: true
       become_user: postgres
       community.postgresql.postgresql_db:
         name: "{{ db_name }}"
       failed_when: false
-      become: true
 
     - name: Apply postgres_backup role  # noqa role-name[path]
       ansible.builtin.import_role:

--- a/src/roles/data_systems/postgresql/postgresql_monitoring/tasks/install_exporter.yml
+++ b/src/roles/data_systems/postgresql/postgresql_monitoring/tasks/install_exporter.yml
@@ -53,8 +53,8 @@
     role_attr_flags: LOGIN
     login_db: "{{ postgresql_exporter_database }}"
     state: present
-  become_user: postgres
   become: true
+  become_user: postgres
 
 - name: Grant monitoring privileges to exporter user
   community.postgresql.postgresql_privs:
@@ -63,17 +63,17 @@
     type: database
     roles: "{{ postgresql_exporter_user }}"
     state: present
-  become_user: postgres
   become: true
+  become_user: postgres
 
 - name: Grant pg_monitor role to exporter user (PostgreSQL 10+)
   community.postgresql.postgresql_user:
     name: "{{ postgresql_exporter_user }}"
     role_attr_flags: pg_monitor
     state: present
+  become: true
   become_user: postgres
   when: postgresql_version | int >= 10
-  become: true
 
 - name: Create postgres_exporter configuration
   ansible.builtin.template:

--- a/src/roles/data_systems/postgresql/postgresql_monitoring/tasks/performance_monitoring.yml
+++ b/src/roles/data_systems/postgresql/postgresql_monitoring/tasks/performance_monitoring.yml
@@ -58,5 +58,5 @@
     name: pg_stat_statements
     login_db: "{{ postgresql_exporter_database }}"
     state: present
-  become_user: postgres
   become: true
+  become_user: postgres

--- a/src/roles/data_systems/postgresql/postgresql_pgbouncer/tasks/users.yml
+++ b/src/roles/data_systems/postgresql/postgresql_pgbouncer/tasks/users.yml
@@ -3,8 +3,8 @@
   community.postgresql.postgresql_query:
     login_db: postgres
     query: "SELECT usename, passwd FROM pg_shadow WHERE usename NOT LIKE 'pg_%'"
-  become_user: postgres
   become: true
+  become_user: postgres
   register: postgresql_users
 
 - name: Generate PgBouncer user list

--- a/src/roles/data_systems/postgresql/postgresql_security/tasks/auth_security.yml
+++ b/src/roles/data_systems/postgresql/postgresql_security/tasks/auth_security.yml
@@ -39,6 +39,6 @@
         {% endif %}
       END;
       $$ LANGUAGE plpgsql;
+  become: true
   become_user: postgres
   when: postgresql_password_complexity | bool
-  become: true

--- a/src/roles/data_systems/postgresql/postgresql_security/tasks/database_security.yml
+++ b/src/roles/data_systems/postgresql/postgresql_security/tasks/database_security.yml
@@ -5,9 +5,9 @@
     query: |
       REVOKE CREATE ON SCHEMA public FROM PUBLIC;
       REVOKE ALL ON DATABASE postgres FROM PUBLIC;
+  become: true
   become_user: postgres
   when: postgresql_public_schema_restricted | bool
-  become: true
 
 - name: Set secure default privileges for new objects
   community.postgresql.postgresql_query:
@@ -16,9 +16,9 @@
       ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM PUBLIC;
       ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON SEQUENCES FROM PUBLIC;
       ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON FUNCTIONS FROM PUBLIC;
+  become: true
   become_user: postgres
   when: postgresql_default_privileges_revoked | bool
-  become: true
 
 - name: Create security monitoring views
   community.postgresql.postgresql_query:
@@ -45,6 +45,6 @@
       FROM pg_log
       WHERE message LIKE '%DROP%' OR message LIKE '%DELETE%' OR message LIKE '%TRUNCATE%'
       ORDER BY log_time DESC;
+  become: true
   become_user: postgres
   when: postgresql_security_monitoring_enabled | bool
-  become: true

--- a/src/roles/data_systems/postgresql/postgresql_security/tasks/security_extensions.yml
+++ b/src/roles/data_systems/postgresql/postgresql_security/tasks/security_extensions.yml
@@ -22,9 +22,9 @@
     name: pgaudit
     login_db: postgres
     state: present
+  become: true
   become_user: postgres
   when: "'pgaudit' in postgresql_security_extensions"
-  become: true
 
 - name: Configure pgaudit settings
   ansible.builtin.lineinfile:

--- a/src/roles/operations_management/netbox/backup_netbox/tasks/main.yml
+++ b/src/roles/operations_management/netbox/backup_netbox/tasks/main.yml
@@ -14,8 +14,8 @@
     login_host: "{{ postgres_host }}"
     login_user: "{{ postgres_user }}"
     login_password: "{{ postgres_password }}"
-  become_user: postgres
   become: true
+  become_user: postgres
 
 - name: Archive NetBox media
   community.general.archive:

--- a/src/roles/security_identity/keycloak/keycloak_realm/molecule/default/converge.yml
+++ b/src/roles/security_identity/keycloak/keycloak_realm/molecule/default/converge.yml
@@ -27,7 +27,6 @@
       community.postgresql.postgresql_user:
         name: keycloak
         password: keycloak
-        priv: ALL
 
   roles:
     - role: keycloak

--- a/src/roles/security_identity/keycloak/keycloak_realm/molecule/podman/converge.yml
+++ b/src/roles/security_identity/keycloak/keycloak_realm/molecule/podman/converge.yml
@@ -27,7 +27,6 @@
       community.postgresql.postgresql_user:
         name: keycloak
         password: keycloak
-        priv: ALL
 
   roles:
     - role: keycloak

--- a/src/roles/security_identity/keycloak/molecule/default/converge.yml
+++ b/src/roles/security_identity/keycloak/molecule/default/converge.yml
@@ -19,16 +19,17 @@
         enabled: true
 
     - name: Create database
+      become: true
       become_user: postgres
       community.postgresql.postgresql_db:
         name: keycloak
 
     - name: Create user
+      become: true
       become_user: postgres
       community.postgresql.postgresql_user:
         name: keycloak
         password: keycloak
-        priv: ALL
 
   roles:
     - role: keycloak

--- a/src/roles/security_identity/keycloak/molecule/podman/converge.yml
+++ b/src/roles/security_identity/keycloak/molecule/podman/converge.yml
@@ -16,18 +16,17 @@
         enabled: true
 
     - name: Create database
-      become_user: postgres
       become: true
+      become_user: postgres
       community.postgresql.postgresql_db:
         name: keycloak
 
     - name: Create user
-      become_user: postgres
       become: true
+      become_user: postgres
       community.postgresql.postgresql_user:
         name: keycloak
         password: keycloak
-        priv: ALL
   roles:
     - role: keycloak
       vars:

--- a/src/roles/security_identity/keycloak/molecule/tls/converge.yml
+++ b/src/roles/security_identity/keycloak/molecule/tls/converge.yml
@@ -20,16 +20,17 @@
         enabled: true
 
     - name: Create database
+      become: true
       become_user: postgres
       community.postgresql.postgresql_db:
         name: keycloak
 
     - name: Create user
+      become: true
       become_user: postgres
       community.postgresql.postgresql_user:
         name: keycloak
         password: keycloak
-        priv: ALL
 
     # Create self-signed certificates for testing
     - name: Create certificate directory


### PR DESCRIPTION
## Summary
- add identity role directory to the global Ansible roles path so namespaced roles resolve during linting
- normalize molecule scenarios for keycloak and keycloak_realm by ensuring privilege escalation is explicit and dropping unsupported module parameters
- fix postgres-related tasks (backup, security, monitoring, pgbouncer, netbox) to declare become before become_user so ansible-lint passes

## Testing
- ansible-lint -p src/roles/security_identity/keycloak/molecule/default/converge.yml
- ansible-lint -p src/roles/security_identity/keycloak/molecule/tls/converge.yml
- ansible-lint -p src/identity/linux/roles/keycloak/molecule/default/converge.yml
- ansible-lint -p src/roles/data_systems/postgresql/postgres_backup/molecule/default/converge.yml
- ansible-lint -p src/infrastructure/linux/roles/backup_netbox/tasks/main.yml
- ansible-lint -p src/roles/security_identity/keycloak/keycloak_realm/molecule/default/converge.yml
- ansible-lint -p src/identity/linux/roles/keycloak_realm/molecule/default/converge.yml
- ansible-lint -p src/playbooks/keycloak_dev.yml

------
https://chatgpt.com/codex/tasks/task_e_68f5452c01e4832a81c74f1f136acbd1