### PR TITLE
Enhance base hardening with firewall, SSH, logging, and access controls

### DIFF
--- a/src/infrastructure/linux/roles/base/defaults/main.yml
+++ b/src/infrastructure/linux/roles/base/defaults/main.yml
@@ -3,3 +3,16 @@ base_enable_bootstrap: true
 base_enable_auto_update: true
 base_enable_fail2ban: true
 base_enable_clamav: true
+base_enable_ufw: true
+base_firewall_allow_ssh: true
+base_firewall_allow_ports: []
+base_firewall_allow_interfaces: []
+base_firewall_logging: 'on'
+base_enable_sshd_hardening: true
+base_enable_filebeat: false
+base_filebeat_output_elasticsearch_hosts:
+  - localhost:9200
+base_filebeat_input_type: log
+base_filebeat_paths:
+  - /var/log/*.log
+base_enable_access_controls: false

--- a/src/infrastructure/linux/roles/base/meta/main.yml
+++ b/src/infrastructure/linux/roles/base/meta/main.yml
@@ -16,12 +16,9 @@ dependencies:
   - role: update_system
   - role: robertdebock.bootstrap
     when: base_enable_bootstrap | bool
-  # - role: willshersystems.sshd
   - role: robertdebock.auto_update
     when: base_enable_auto_update | bool
   - role: robertdebock.fail2ban
     when: base_enable_fail2ban | bool
-  # - role: oefenweb.ufw
   - role: geerlingguy.clamav
     when: base_enable_clamav | bool
-  # - role: configure_filebeat_os

--- a/src/infrastructure/linux/roles/base_access_controls/README.md
+++ b/src/infrastructure/linux/roles/base_access_controls/README.md
@@ -1,0 +1,29 @@
+# Base Access Controls
+
+This role provisions baseline administrative accounts and sudo hardening for Linux hosts. It can create standardized admin groups, ensure administrator accounts exist with SSH keys, and install a sudoers drop-in that enforces logging and configurable privilege escalation behavior.
+
+## Role Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `base_access_controls_admin_group` | `admin` | Primary Unix group for administrative accounts. |
+| `base_access_controls_sudo_group` | `sudo` | Group granted sudo privileges in the drop-in policy. |
+| `base_access_controls_accounts` | `[]` | List of dictionaries describing administrative accounts to manage. Each item supports keys like `name`, `state`, `shell`, `primary_group`, `groups`, `ssh_authorized_keys`, and more. |
+| `base_access_controls_default_shell` | `/bin/bash` | Default shell assigned to created accounts. |
+| `base_access_controls_manage_authorized_keys` | `true` | Whether to manage SSH authorized keys declared for each account. |
+| `base_access_controls_sudo_nopasswd` | `false` | When `true`, grants passwordless sudo privileges to the configured group. |
+| `base_access_controls_sudo_logfile` | `/var/log/sudo.log` | Log file path recorded via the sudoers drop-in. |
+| `base_access_controls_sudo_log_input` | `true` | Enable sudo I/O logging for commands run by the admin group. |
+| `base_access_controls_sudo_log_output` | `true` | Enable logging of sudo command output. |
+| `base_access_controls_sudo_passwd_timeout` | `5` | Timeout (in minutes) before sudo re-prompts for a password. |
+| `base_access_controls_sudo_extra_directives` | `[]` | Additional raw sudoers directives to append to the drop-in. |
+
+## Example
+
+```yaml
+base_access_controls_accounts:
+  - name: opsadmin
+    comment: Platform Operations
+    ssh_authorized_keys:
+      - "ssh-ed25519 AAAA..."
+```

--- a/src/infrastructure/linux/roles/base_access_controls/defaults/main.yml
+++ b/src/infrastructure/linux/roles/base_access_controls/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+base_access_controls_admin_group: admin
+base_access_controls_sudo_group: sudo
+base_access_controls_accounts: []
+base_access_controls_default_shell: /bin/bash
+base_access_controls_manage_authorized_keys: true
+base_access_controls_sudo_nopasswd: false
+base_access_controls_sudo_logfile: /var/log/sudo.log
+base_access_controls_sudo_log_input: true
+base_access_controls_sudo_log_output: true
+base_access_controls_sudo_passwd_timeout: 5
+base_access_controls_sudo_extra_directives: []

--- a/src/infrastructure/linux/roles/base_access_controls/meta/main.yml
+++ b/src/infrastructure/linux/roles/base_access_controls/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  author: Example Inc.
+  description: Baseline administrative account and sudo hardening controls.
+  license: MIT
+  min_ansible_version: "2.13"
+  platforms:
+    - name: Debian
+      versions: [bullseye, bookworm]
+    - name: Ubuntu
+      versions: [focal, jammy]
+dependencies: []

--- a/src/infrastructure/linux/roles/base_access_controls/tasks/main.yml
+++ b/src/infrastructure/linux/roles/base_access_controls/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+- name: Ensure administrative group exists
+  ansible.builtin.group:
+    name: "{{ base_access_controls_admin_group }}"
+    state: present
+
+- name: Ensure sudo group exists
+  ansible.builtin.group:
+    name: "{{ base_access_controls_sudo_group }}"
+    state: present
+
+- name: Manage administrative accounts
+  ansible.builtin.user:
+    name: "{{ item.name }}"
+    state: "{{ item.state | default('present') }}"
+    shell: "{{ item.shell | default(base_access_controls_default_shell) }}"
+    group: "{{ item.primary_group | default(base_access_controls_admin_group | default('admin')) }}"
+    groups: >-
+      {{ (
+          (item.groups | default([]))
+          + [
+            base_access_controls_admin_group | default('admin'),
+            base_access_controls_sudo_group | default('sudo')
+          ]
+        ) | unique | join(',') }}
+    append: "{{ item.append | default(true) }}"
+    create_home: "{{ item.create_home | default(true) }}"
+    password: "{{ item.password | default(omit) }}"
+    update_password: "{{ item.update_password | default('on_create') }}"
+    expires: "{{ item.expires | default(omit) }}"
+    comment: "{{ item.comment | default(omit) }}"
+    uid: "{{ item.uid | default(omit) }}"
+  loop: "{{ base_access_controls_accounts }}"
+  when:
+    - base_access_controls_accounts | length > 0
+    - (item.state | default('present')) != 'absent'
+
+- name: Remove retired administrative accounts
+  ansible.builtin.user:
+    name: "{{ item.name }}"
+    state: absent
+    remove: "{{ item.remove | default(false) }}"
+  loop: "{{ base_access_controls_accounts }}"
+  when:
+    - base_access_controls_accounts | length > 0
+    - (item.state | default('present')) == 'absent'
+
+- name: Configure administrative authorized keys
+  ansible.posix.authorized_key:
+    user: "{{ item.0.name }}"
+    key: "{{ item.1 }}"
+    state: present
+    manage_dir: true
+  loop: "{{ base_access_controls_accounts | subelements('ssh_authorized_keys', skip_missing=True) }}"
+  when:
+    - base_access_controls_manage_authorized_keys | bool
+    - (item.0.state | default('present')) != 'absent'
+
+- name: Install sudo hardening drop-in
+  ansible.builtin.template:
+    src: sudoers-base-admins.j2
+    dest: /etc/sudoers.d/99-base-admins
+    owner: root
+    group: root
+    mode: "0440"
+    validate: "visudo -cf %s"

--- a/src/infrastructure/linux/roles/base_access_controls/templates/sudoers-base-admins.j2
+++ b/src/infrastructure/linux/roles/base_access_controls/templates/sudoers-base-admins.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+Defaults:%{{ base_access_controls_sudo_group }} logfile="{{ base_access_controls_sudo_logfile }}"
+{% if base_access_controls_sudo_log_input %}
+Defaults:%{{ base_access_controls_sudo_group }} log_input
+{% endif %}
+{% if base_access_controls_sudo_log_output %}
+Defaults:%{{ base_access_controls_sudo_group }} log_output
+{% endif %}
+Defaults:%{{ base_access_controls_sudo_group }} passwd_timeout={{ base_access_controls_sudo_passwd_timeout }}
+{% for directive in base_access_controls_sudo_extra_directives %}
+{{ directive }}
+{% endfor %}
+%{{ base_access_controls_sudo_group }} ALL=(ALL:ALL) {{ 'NOPASSWD:ALL' if base_access_controls_sudo_nopasswd else 'ALL' }}

--- a/src/roles/infrastructure/shared/base/meta/main.yml
+++ b/src/roles/infrastructure/shared/base/meta/main.yml
@@ -16,12 +16,9 @@ dependencies:
   - role: update_system
   - role: robertdebock.bootstrap
     when: base_enable_bootstrap | bool
-  # - role: willshersystems.sshd
   - role: robertdebock.auto_update
     when: base_enable_auto_update | bool
   - role: robertdebock.fail2ban
     when: base_enable_fail2ban | bool
-  # - role: oefenweb.ufw
   - role: geerlingguy.clamav
     when: base_enable_clamav | bool
-  # - role: configure_filebeat_os

--- a/src/roles/infrastructure/shared/base/tasks/main.yml
+++ b/src/roles/infrastructure/shared/base/tasks/main.yml
@@ -1,8 +1,35 @@
 ---
 # Base role main tasks file
-# This role orchestrates internal dependency roles to establish a baseline system state.
-# Dependency roles executed automatically via meta/main.yml.
-# Placeholder for future hardening or baseline tasks specific to this role.
-- name: Base role placeholder debug
+# This role orchestrates optional hardening components controlled by base_* variables.
+- name: Configure host-based firewall
+  ansible.builtin.include_role:
+    name: ufw
+  vars:
+    ufw_allow_ssh: "{{ base_firewall_allow_ssh }}"
+    ufw_allow_ports: "{{ base_firewall_allow_ports }}"
+    ufw_allow_interfaces: "{{ base_firewall_allow_interfaces }}"
+    ufw_logging: "{{ base_firewall_logging }}"
+  when: base_enable_ufw | bool
+
+- name: Apply SSH daemon hardening profile
+  ansible.builtin.include_role:
+    name: sshd
+  when: base_enable_sshd_hardening | bool
+
+- name: Configure Filebeat OS log forwarding
+  ansible.builtin.include_role:
+    name: configure_filebeat_os
+  vars:
+    configure_filebeat_os_output_elasticsearch_hosts: "{{ base_filebeat_output_elasticsearch_hosts }}"
+    configure_filebeat_os_input_type: "{{ base_filebeat_input_type }}"
+    configure_filebeat_os_paths: "{{ base_filebeat_paths }}"
+  when: base_enable_filebeat | bool
+
+- name: Enforce baseline administrative access controls
+  ansible.builtin.include_role:
+    name: base_access_controls
+  when: base_enable_access_controls | bool
+
+- name: Base role summary debug
   ansible.builtin.debug:
-    msg: "Base role executed (dependencies handled via meta)."
+    msg: "Base role executed (core dependencies handled via meta)."

--- a/src/roles/infrastructure/shared/base_access_controls/README.md
+++ b/src/roles/infrastructure/shared/base_access_controls/README.md
@@ -1,0 +1,29 @@
+# Base Access Controls
+
+This role provisions baseline administrative accounts and sudo hardening for Linux hosts. It can create standardized admin groups, ensure administrator accounts exist with SSH keys, and install a sudoers drop-in that enforces logging and configurable privilege escalation behavior.
+
+## Role Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `base_access_controls_admin_group` | `admin` | Primary Unix group for administrative accounts. |
+| `base_access_controls_sudo_group` | `sudo` | Group granted sudo privileges in the drop-in policy. |
+| `base_access_controls_accounts` | `[]` | List of dictionaries describing administrative accounts to manage. Each item supports keys like `name`, `state`, `shell`, `primary_group`, `groups`, `ssh_authorized_keys`, and more. |
+| `base_access_controls_default_shell` | `/bin/bash` | Default shell assigned to created accounts. |
+| `base_access_controls_manage_authorized_keys` | `true` | Whether to manage SSH authorized keys declared for each account. |
+| `base_access_controls_sudo_nopasswd` | `false` | When `true`, grants passwordless sudo privileges to the configured group. |
+| `base_access_controls_sudo_logfile` | `/var/log/sudo.log` | Log file path recorded via the sudoers drop-in. |
+| `base_access_controls_sudo_log_input` | `true` | Enable sudo I/O logging for commands run by the admin group. |
+| `base_access_controls_sudo_log_output` | `true` | Enable logging of sudo command output. |
+| `base_access_controls_sudo_passwd_timeout` | `5` | Timeout (in minutes) before sudo re-prompts for a password. |
+| `base_access_controls_sudo_extra_directives` | `[]` | Additional raw sudoers directives to append to the drop-in. |
+
+## Example
+
+```yaml
+base_access_controls_accounts:
+  - name: opsadmin
+    comment: Platform Operations
+    ssh_authorized_keys:
+      - "ssh-ed25519 AAAA..."
+```

--- a/src/roles/infrastructure/shared/base_access_controls/defaults/main.yml
+++ b/src/roles/infrastructure/shared/base_access_controls/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+base_access_controls_admin_group: admin
+base_access_controls_sudo_group: sudo
+base_access_controls_accounts: []
+base_access_controls_default_shell: /bin/bash
+base_access_controls_manage_authorized_keys: true
+base_access_controls_sudo_nopasswd: false
+base_access_controls_sudo_logfile: /var/log/sudo.log
+base_access_controls_sudo_log_input: true
+base_access_controls_sudo_log_output: true
+base_access_controls_sudo_passwd_timeout: 5
+base_access_controls_sudo_extra_directives: []

--- a/src/roles/infrastructure/shared/base_access_controls/meta/main.yml
+++ b/src/roles/infrastructure/shared/base_access_controls/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  author: Example Inc.
+  description: Baseline administrative account and sudo hardening controls.
+  license: MIT
+  min_ansible_version: "2.13"
+  platforms:
+    - name: Debian
+      versions: [bullseye, bookworm]
+    - name: Ubuntu
+      versions: [focal, jammy]
+dependencies: []

--- a/src/roles/infrastructure/shared/base_access_controls/tasks/main.yml
+++ b/src/roles/infrastructure/shared/base_access_controls/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+- name: Ensure administrative group exists
+  ansible.builtin.group:
+    name: "{{ base_access_controls_admin_group }}"
+    state: present
+
+- name: Ensure sudo group exists
+  ansible.builtin.group:
+    name: "{{ base_access_controls_sudo_group }}"
+    state: present
+
+- name: Manage administrative accounts
+  ansible.builtin.user:
+    name: "{{ item.name }}"
+    state: "{{ item.state | default('present') }}"
+    shell: "{{ item.shell | default(base_access_controls_default_shell) }}"
+    group: "{{ item.primary_group | default(base_access_controls_admin_group | default('admin')) }}"
+    groups: >-
+      {{ (
+          (item.groups | default([]))
+          + [
+            base_access_controls_admin_group | default('admin'),
+            base_access_controls_sudo_group | default('sudo')
+          ]
+        ) | unique | join(',') }}
+    append: "{{ item.append | default(true) }}"
+    create_home: "{{ item.create_home | default(true) }}"
+    password: "{{ item.password | default(omit) }}"
+    update_password: "{{ item.update_password | default('on_create') }}"
+    expires: "{{ item.expires | default(omit) }}"
+    comment: "{{ item.comment | default(omit) }}"
+    uid: "{{ item.uid | default(omit) }}"
+  loop: "{{ base_access_controls_accounts }}"
+  when:
+    - base_access_controls_accounts | length > 0
+    - (item.state | default('present')) != 'absent'
+
+- name: Remove retired administrative accounts
+  ansible.builtin.user:
+    name: "{{ item.name }}"
+    state: absent
+    remove: "{{ item.remove | default(false) }}"
+  loop: "{{ base_access_controls_accounts }}"
+  when:
+    - base_access_controls_accounts | length > 0
+    - (item.state | default('present')) == 'absent'
+
+- name: Configure administrative authorized keys
+  ansible.posix.authorized_key:
+    user: "{{ item.0.name }}"
+    key: "{{ item.1 }}"
+    state: present
+    manage_dir: true
+  loop: "{{ base_access_controls_accounts | subelements('ssh_authorized_keys', skip_missing=True) }}"
+  when:
+    - base_access_controls_manage_authorized_keys | bool
+    - (item.0.state | default('present')) != 'absent'
+
+- name: Install sudo hardening drop-in
+  ansible.builtin.template:
+    src: sudoers-base-admins.j2
+    dest: /etc/sudoers.d/99-base-admins
+    owner: root
+    group: root
+    mode: "0440"
+    validate: "visudo -cf %s"

--- a/src/roles/infrastructure/shared/base_access_controls/templates/sudoers-base-admins.j2
+++ b/src/roles/infrastructure/shared/base_access_controls/templates/sudoers-base-admins.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+Defaults:%{{ base_access_controls_sudo_group }} logfile="{{ base_access_controls_sudo_logfile }}"
+{% if base_access_controls_sudo_log_input %}
+Defaults:%{{ base_access_controls_sudo_group }} log_input
+{% endif %}
+{% if base_access_controls_sudo_log_output %}
+Defaults:%{{ base_access_controls_sudo_group }} log_output
+{% endif %}
+Defaults:%{{ base_access_controls_sudo_group }} passwd_timeout={{ base_access_controls_sudo_passwd_timeout }}
+{% for directive in base_access_controls_sudo_extra_directives %}
+{{ directive }}
+{% endfor %}
+%{{ base_access_controls_sudo_group }} ALL=(ALL:ALL) {{ 'NOPASSWD:ALL' if base_access_controls_sudo_nopasswd else 'ALL' }}

--- a/src/roles/infrastructure/shared/sshd/defaults/main.yml
+++ b/src/roles/infrastructure/shared/sshd/defaults/main.yml
@@ -1,2 +1,56 @@
 ---
-sshd_listen_address: "{{ hostvars[inventory_hostname]['ansible_host'] }}"
+sshd_port: 22
+sshd_address_family: inet
+sshd_protocol: 2
+sshd_listen_address: "{{ hostvars[inventory_hostname]['ansible_host'] | default('0.0.0.0') }}"
+sshd_listen_addresses: []
+sshd_permit_root_login: "no"
+sshd_password_authentication: "no"
+sshd_permit_empty_passwords: "no"
+sshd_challenge_response_authentication: "no"
+sshd_kbd_interactive_authentication: "no"
+sshd_use_pam: "yes"
+sshd_pubkey_authentication: "yes"
+sshd_authentication_methods: "publickey"
+sshd_hostbased_authentication: "no"
+sshd_ignore_rhosts: "yes"
+sshd_gssapi_authentication: "no"
+sshd_x11_forwarding: "no"
+sshd_allow_tcp_forwarding: "no"
+sshd_allow_agent_forwarding: "no"
+sshd_compression: "no"
+sshd_client_alive_interval: 300
+sshd_client_alive_count_max: 2
+sshd_login_grace_time: 30
+sshd_max_auth_tries: 3
+sshd_max_sessions: 10
+sshd_authorized_keys_file: ".ssh/authorized_keys"
+sshd_sftp_subsystem: /usr/lib/openssh/sftp-server
+sshd_log_level: VERBOSE
+sshd_syslog_facility: AUTHPRIV
+sshd_print_motd: "no"
+sshd_tcp_keep_alive: "no"
+sshd_allow_groups: []
+sshd_allow_users: []
+sshd_deny_groups: []
+sshd_deny_users: []
+sshd_banner: ""
+sshd_ciphers:
+  - chacha20-poly1305@openssh.com
+  - aes256-gcm@openssh.com
+  - aes128-gcm@openssh.com
+  - aes256-ctr
+  - aes192-ctr
+  - aes128-ctr
+sshd_macs:
+  - hmac-sha2-512-etm@openssh.com
+  - hmac-sha2-256-etm@openssh.com
+  - umac-128-etm@openssh.com
+  - hmac-sha2-512
+  - hmac-sha2-256
+sshd_kex_algorithms:
+  - curve25519-sha256
+  - curve25519-sha256@libssh.org
+  - ecdh-sha2-nistp521
+  - ecdh-sha2-nistp384
+  - ecdh-sha2-nistp256

--- a/src/roles/infrastructure/shared/sshd/templates/sshd_config.j2
+++ b/src/roles/infrastructure/shared/sshd/templates/sshd_config.j2
@@ -1,3 +1,52 @@
 # {{ ansible_managed }}
-Port 22
-AddressFamily inet
+Port {{ sshd_port }}
+AddressFamily {{ sshd_address_family }}
+Protocol {{ sshd_protocol }}
+{% set listen_list = sshd_listen_addresses if sshd_listen_addresses else ([sshd_listen_address] if sshd_listen_address else []) %}
+{% for addr in listen_list %}
+ListenAddress {{ addr }}
+{% endfor %}
+SyslogFacility {{ sshd_syslog_facility }}
+LogLevel {{ sshd_log_level }}
+PermitRootLogin {{ sshd_permit_root_login }}
+PasswordAuthentication {{ sshd_password_authentication }}
+PermitEmptyPasswords {{ sshd_permit_empty_passwords }}
+KbdInteractiveAuthentication {{ sshd_kbd_interactive_authentication }}
+ChallengeResponseAuthentication {{ sshd_challenge_response_authentication }}
+UsePAM {{ sshd_use_pam }}
+PubkeyAuthentication {{ sshd_pubkey_authentication }}
+AuthenticationMethods {{ sshd_authentication_methods }}
+HostbasedAuthentication {{ sshd_hostbased_authentication }}
+IgnoreRhosts {{ sshd_ignore_rhosts }}
+GSSAPIAuthentication {{ sshd_gssapi_authentication }}
+X11Forwarding {{ sshd_x11_forwarding }}
+AllowTcpForwarding {{ sshd_allow_tcp_forwarding }}
+AllowAgentForwarding {{ sshd_allow_agent_forwarding }}
+Compression {{ sshd_compression }}
+ClientAliveInterval {{ sshd_client_alive_interval }}
+ClientAliveCountMax {{ sshd_client_alive_count_max }}
+LoginGraceTime {{ sshd_login_grace_time }}
+MaxAuthTries {{ sshd_max_auth_tries }}
+MaxSessions {{ sshd_max_sessions }}
+TCPKeepAlive {{ sshd_tcp_keep_alive }}
+PrintMotd {{ sshd_print_motd }}
+AuthorizedKeysFile {{ sshd_authorized_keys_file }}
+Ciphers {{ sshd_ciphers | join(',') }}
+MACs {{ sshd_macs | join(',') }}
+KexAlgorithms {{ sshd_kex_algorithms | join(',') }}
+Subsystem sftp {{ sshd_sftp_subsystem }}
+{% if sshd_allow_groups %}
+AllowGroups {{ sshd_allow_groups | join(' ') }}
+{% endif %}
+{% if sshd_allow_users %}
+AllowUsers {{ sshd_allow_users | join(' ') }}
+{% endif %}
+{% if sshd_deny_users %}
+DenyUsers {{ sshd_deny_users | join(' ') }}
+{% endif %}
+{% if sshd_deny_groups %}
+DenyGroups {{ sshd_deny_groups | join(' ') }}
+{% endif %}
+{% if sshd_banner %}
+Banner {{ sshd_banner }}
+{% endif %}

--- a/src/roles/infrastructure/shared/ufw/README.md
+++ b/src/roles/infrastructure/shared/ufw/README.md
@@ -65,6 +65,11 @@ Below is a list of variables used by the role, along with default values (define
 | **`ufw_allow_ports`**      | `[]` (empty list) | List of additional incoming ports (or port ranges) to allow. Each entry in the list should be a port number or range (e.g. `80` for HTTP or `6000:6100` for a range). The role will create an allow rule for each specified port (using TCP by default). This is useful for permitting application-specific ports (web, database, etc.). **Note:** Removing a port from this list will **not** automatically close that port if it was previously opened (see **Known Issues**). |
 | **`ufw_allow_interfaces`** | `[]` (empty list) | List of network interface names from which to allow all traffic (incoming). If specified, the role will create allow rules for all incoming packets on each given interface. For example, you might include `lo` to ensure all loopback traffic is accepted, or an internal interface like `eth1` if you trust all traffic on that network. **Important:** Use actual interface identifiers (e.g. `"eth1"`, `"ens3"`, `"lo"`); do not list protocols (such as "tcp") here.       |
 
+| **`ufw_logging`**             | `on`              | Logging level passed to UFW (`off`, `low`, `medium`, `high`, or `on`). |
+| **`ufw_default_incoming_policy`** | `deny`            | Default policy applied to incoming traffic when the firewall is enabled. |
+| **`ufw_default_outgoing_policy`** | `allow`           | Default policy applied to outbound traffic when the firewall is enabled. |
+| **`ufw_additional_rules`**     | `[]`              | List of dictionaries for advanced rules (fields such as `rule`, `port`, `proto`, `from_ip`, `to_ip`, `name`, `direction`, `interface`). |
+
 </details>
 
 <!-- markdownlint-enable MD033 -->

--- a/src/roles/infrastructure/shared/ufw/defaults/main.yml
+++ b/src/roles/infrastructure/shared/ufw/defaults/main.yml
@@ -10,3 +10,7 @@ ufw_allow_ports: []
 
 # Allow specific interfaces
 ufw_allow_interfaces: []
+ufw_logging: 'on'
+ufw_default_incoming_policy: 'deny'
+ufw_default_outgoing_policy: 'allow'
+ufw_additional_rules: []

--- a/src/roles/infrastructure/shared/ufw/tasks/ufw.yml
+++ b/src/roles/infrastructure/shared/ufw/tasks/ufw.yml
@@ -1,7 +1,17 @@
 ---
+- name: "UFW: Set default policies"
+  community.general.ufw:
+    direction: "{{ item.direction }}"
+    policy: "{{ item.policy }}"
+  loop:
+    - direction: incoming
+      policy: "{{ ufw_default_incoming_policy }}"
+    - direction: outgoing
+      policy: "{{ ufw_default_outgoing_policy }}"
+
 - name: "UFW: Set logging"
   community.general.ufw:
-    logging: 'on'
+    logging: "{{ ufw_logging }}"
 
 # We explicitly manage SSH rule
 - name: "UFW: Allow SSH"
@@ -16,6 +26,18 @@
     rule: allow
     port: "{{ item }}"
   loop: "{{ ufw_allow_ports }}"
+
+- name: "UFW: Apply additional rules"
+  community.general.ufw:
+    rule: "{{ item.rule | default('allow') }}"
+    port: "{{ item.port | default(omit) }}"
+    proto: "{{ item.proto | default(omit) }}"
+    from_ip: "{{ item.from_ip | default(omit) }}"
+    to_ip: "{{ item.to_ip | default(omit) }}"
+    name: "{{ item.name | default(omit) }}"
+    direction: "{{ item.direction | default(omit) }}"
+    interface: "{{ item.interface | default(omit) }}"
+  loop: "{{ ufw_additional_rules }}"
 
 # Allow specific interfaces
 - name: Accept packets from interfaces

--- a/src/security/linux/roles/sshd/defaults/main.yml
+++ b/src/security/linux/roles/sshd/defaults/main.yml
@@ -1,2 +1,56 @@
 ---
-sshd_listen_address: "{{ hostvars[inventory_hostname]['ansible_host'] }}"
+sshd_port: 22
+sshd_address_family: inet
+sshd_protocol: 2
+sshd_listen_address: "{{ hostvars[inventory_hostname]['ansible_host'] | default('0.0.0.0') }}"
+sshd_listen_addresses: []
+sshd_permit_root_login: "no"
+sshd_password_authentication: "no"
+sshd_permit_empty_passwords: "no"
+sshd_challenge_response_authentication: "no"
+sshd_kbd_interactive_authentication: "no"
+sshd_use_pam: "yes"
+sshd_pubkey_authentication: "yes"
+sshd_authentication_methods: "publickey"
+sshd_hostbased_authentication: "no"
+sshd_ignore_rhosts: "yes"
+sshd_gssapi_authentication: "no"
+sshd_x11_forwarding: "no"
+sshd_allow_tcp_forwarding: "no"
+sshd_allow_agent_forwarding: "no"
+sshd_compression: "no"
+sshd_client_alive_interval: 300
+sshd_client_alive_count_max: 2
+sshd_login_grace_time: 30
+sshd_max_auth_tries: 3
+sshd_max_sessions: 10
+sshd_authorized_keys_file: ".ssh/authorized_keys"
+sshd_sftp_subsystem: /usr/lib/openssh/sftp-server
+sshd_log_level: VERBOSE
+sshd_syslog_facility: AUTHPRIV
+sshd_print_motd: "no"
+sshd_tcp_keep_alive: "no"
+sshd_allow_groups: []
+sshd_allow_users: []
+sshd_deny_groups: []
+sshd_deny_users: []
+sshd_banner: ""
+sshd_ciphers:
+  - chacha20-poly1305@openssh.com
+  - aes256-gcm@openssh.com
+  - aes128-gcm@openssh.com
+  - aes256-ctr
+  - aes192-ctr
+  - aes128-ctr
+sshd_macs:
+  - hmac-sha2-512-etm@openssh.com
+  - hmac-sha2-256-etm@openssh.com
+  - umac-128-etm@openssh.com
+  - hmac-sha2-512
+  - hmac-sha2-256
+sshd_kex_algorithms:
+  - curve25519-sha256
+  - curve25519-sha256@libssh.org
+  - ecdh-sha2-nistp521
+  - ecdh-sha2-nistp384
+  - ecdh-sha2-nistp256

--- a/src/security/linux/roles/sshd/templates/sshd_config.j2
+++ b/src/security/linux/roles/sshd/templates/sshd_config.j2
@@ -1,3 +1,52 @@
 # {{ ansible_managed }}
-Port 22
-AddressFamily inet
+Port {{ sshd_port }}
+AddressFamily {{ sshd_address_family }}
+Protocol {{ sshd_protocol }}
+{% set listen_list = sshd_listen_addresses if sshd_listen_addresses else ([sshd_listen_address] if sshd_listen_address else []) %}
+{% for addr in listen_list %}
+ListenAddress {{ addr }}
+{% endfor %}
+SyslogFacility {{ sshd_syslog_facility }}
+LogLevel {{ sshd_log_level }}
+PermitRootLogin {{ sshd_permit_root_login }}
+PasswordAuthentication {{ sshd_password_authentication }}
+PermitEmptyPasswords {{ sshd_permit_empty_passwords }}
+KbdInteractiveAuthentication {{ sshd_kbd_interactive_authentication }}
+ChallengeResponseAuthentication {{ sshd_challenge_response_authentication }}
+UsePAM {{ sshd_use_pam }}
+PubkeyAuthentication {{ sshd_pubkey_authentication }}
+AuthenticationMethods {{ sshd_authentication_methods }}
+HostbasedAuthentication {{ sshd_hostbased_authentication }}
+IgnoreRhosts {{ sshd_ignore_rhosts }}
+GSSAPIAuthentication {{ sshd_gssapi_authentication }}
+X11Forwarding {{ sshd_x11_forwarding }}
+AllowTcpForwarding {{ sshd_allow_tcp_forwarding }}
+AllowAgentForwarding {{ sshd_allow_agent_forwarding }}
+Compression {{ sshd_compression }}
+ClientAliveInterval {{ sshd_client_alive_interval }}
+ClientAliveCountMax {{ sshd_client_alive_count_max }}
+LoginGraceTime {{ sshd_login_grace_time }}
+MaxAuthTries {{ sshd_max_auth_tries }}
+MaxSessions {{ sshd_max_sessions }}
+TCPKeepAlive {{ sshd_tcp_keep_alive }}
+PrintMotd {{ sshd_print_motd }}
+AuthorizedKeysFile {{ sshd_authorized_keys_file }}
+Ciphers {{ sshd_ciphers | join(',') }}
+MACs {{ sshd_macs | join(',') }}
+KexAlgorithms {{ sshd_kex_algorithms | join(',') }}
+Subsystem sftp {{ sshd_sftp_subsystem }}
+{% if sshd_allow_groups %}
+AllowGroups {{ sshd_allow_groups | join(' ') }}
+{% endif %}
+{% if sshd_allow_users %}
+AllowUsers {{ sshd_allow_users | join(' ') }}
+{% endif %}
+{% if sshd_deny_users %}
+DenyUsers {{ sshd_deny_users | join(' ') }}
+{% endif %}
+{% if sshd_deny_groups %}
+DenyGroups {{ sshd_deny_groups | join(' ') }}
+{% endif %}
+{% if sshd_banner %}
+Banner {{ sshd_banner }}
+{% endif %}

--- a/src/security/linux/roles/ufw/README.md
+++ b/src/security/linux/roles/ufw/README.md
@@ -65,6 +65,11 @@ Below is a list of variables used by the role, along with default values (define
 | **`ufw_allow_ports`**      | `[]` (empty list) | List of additional incoming ports (or port ranges) to allow. Each entry in the list should be a port number or range (e.g. `80` for HTTP or `6000:6100` for a range). The role will create an allow rule for each specified port (using TCP by default). This is useful for permitting application-specific ports (web, database, etc.). **Note:** Removing a port from this list will **not** automatically close that port if it was previously opened (see **Known Issues**). |
 | **`ufw_allow_interfaces`** | `[]` (empty list) | List of network interface names from which to allow all traffic (incoming). If specified, the role will create allow rules for all incoming packets on each given interface. For example, you might include `lo` to ensure all loopback traffic is accepted, or an internal interface like `eth1` if you trust all traffic on that network. **Important:** Use actual interface identifiers (e.g. `"eth1"`, `"ens3"`, `"lo"`); do not list protocols (such as "tcp") here.       |
 
+| **`ufw_logging`**             | `on`              | Logging level passed to UFW (`off`, `low`, `medium`, `high`, or `on`). |
+| **`ufw_default_incoming_policy`** | `deny`            | Default policy applied to incoming traffic when the firewall is enabled. |
+| **`ufw_default_outgoing_policy`** | `allow`           | Default policy applied to outbound traffic when the firewall is enabled. |
+| **`ufw_additional_rules`**     | `[]`              | List of dictionaries for advanced rules (fields such as `rule`, `port`, `proto`, `from_ip`, `to_ip`, `name`, `direction`, `interface`). |
+
 </details>
 
 <!-- markdownlint-enable MD033 -->

--- a/src/security/linux/roles/ufw/defaults/main.yml
+++ b/src/security/linux/roles/ufw/defaults/main.yml
@@ -10,3 +10,7 @@ ufw_allow_ports: []
 
 # Allow specific interfaces
 ufw_allow_interfaces: []
+ufw_logging: 'on'
+ufw_default_incoming_policy: 'deny'
+ufw_default_outgoing_policy: 'allow'
+ufw_additional_rules: []

--- a/src/security/linux/roles/ufw/tasks/ufw.yml
+++ b/src/security/linux/roles/ufw/tasks/ufw.yml
@@ -1,7 +1,17 @@
 ---
+- name: "UFW: Set default policies"
+  community.general.ufw:
+    direction: "{{ item.direction }}"
+    policy: "{{ item.policy }}"
+  loop:
+    - direction: incoming
+      policy: "{{ ufw_default_incoming_policy }}"
+    - direction: outgoing
+      policy: "{{ ufw_default_outgoing_policy }}"
+
 - name: "UFW: Set logging"
   community.general.ufw:
-    logging: 'on'
+    logging: "{{ ufw_logging }}"
 
 # We explicitly manage SSH rule
 - name: "UFW: Allow SSH"
@@ -16,6 +26,18 @@
     rule: allow
     port: "{{ item }}"
   loop: "{{ ufw_allow_ports }}"
+
+- name: "UFW: Apply additional rules"
+  community.general.ufw:
+    rule: "{{ item.rule | default('allow') }}"
+    port: "{{ item.port | default(omit) }}"
+    proto: "{{ item.proto | default(omit) }}"
+    from_ip: "{{ item.from_ip | default(omit) }}"
+    to_ip: "{{ item.to_ip | default(omit) }}"
+    name: "{{ item.name | default(omit) }}"
+    direction: "{{ item.direction | default(omit) }}"
+    interface: "{{ item.interface | default(omit) }}"
+  loop: "{{ ufw_additional_rules }}"
 
 # Allow specific interfaces
 - name: Accept packets from interfaces


### PR DESCRIPTION
## Summary
- enable optional host firewall, SSH hardening, Filebeat forwarding, and account controls for the base role with updated documentation
- introduce a reusable `base_access_controls` role and expand the UFW/SSHD defaults to support stricter policies and logging

## Testing
- ansible-lint src/infrastructure/linux/roles/base/defaults/main.yml
- ansible-lint src/roles/infrastructure/shared/base/tasks/main.yml
- ansible-lint src/roles/infrastructure/shared/base_access_controls/tasks/main.yml
- ansible-lint src/infrastructure/linux/roles/base_access_controls/tasks/main.yml
- ansible-lint src/security/linux/roles/ufw/tasks/ufw.yml
- ansible-lint src/roles/infrastructure/shared/ufw/tasks/ufw.yml
- ansible-lint src/security/linux/roles/sshd/defaults/main.yml
- ansible-lint src/roles/infrastructure/shared/sshd/defaults/main.yml

------
https://chatgpt.com/codex/tasks/task_e_68f5464ace44832a890029d7caf4f126