### PR TITLE
Fix Filebeat lint issues, add keystore support, and unify inventory/Proxmox scripts

### DIFF
--- a/src/roles/monitoring_observability/filebeat/defaults/main.yml
+++ b/src/roles/monitoring_observability/filebeat/defaults/main.yml
@@ -115,6 +115,8 @@ filebeat_ssl_curve_types: []
 filebeat_api_key_enabled: false
 filebeat_api_key_id: ""
 filebeat_api_key_value: ""
+filebeat_use_keystore: false
+filebeat_keystore_keys: {}
 
 # Processing Configuration
 # ----------------------------------------------------------------------------
@@ -197,3 +199,8 @@ filebeat_custom_config: {}
 # Template rendering options
 filebeat_template_backup: true
 filebeat_template_validate: true
+
+# Configuration file ownership
+filebeat_config_file_owner: "{{ filebeat_user }}"
+filebeat_config_file_group: "{{ filebeat_group }}"
+filebeat_config_file_mode: "0644"

--- a/src/roles/monitoring_observability/filebeat/examples/advanced-deployment.yml
+++ b/src/roles/monitoring_observability/filebeat/examples/advanced-deployment.yml
@@ -2,7 +2,7 @@
 # Advanced Filebeat deployment with SSL and multiple inputs
 - name: Deploy Filebeat with advanced configuration
   hosts: production_servers
-  become: yes
+  become: true
   vars:
     # Multiple input sources
     filebeat_inputs:
@@ -99,7 +99,7 @@
     filebeat_config_validate_before_restart: true
 
   roles:
-    - monitoring_observability.filebeat
+    - filebeat
 
   tags:
     - monitoring

--- a/src/roles/monitoring_observability/filebeat/examples/basic-deployment.yml
+++ b/src/roles/monitoring_observability/filebeat/examples/basic-deployment.yml
@@ -2,7 +2,7 @@
 # Basic Filebeat deployment example
 - name: Deploy Filebeat with basic configuration
   hosts: web_servers
-  become: yes
+  become: true
   vars:
     filebeat_inputs:
       - type: log
@@ -21,7 +21,7 @@
 
     # Point to Logstash nodes deployed via the data_systems/logstash role
     filebeat_output_type: logstash
-    filebeat_logstash_hosts: {{ groups['logstash_servers'] | default(['logstash1.example.com']) | map('regex_replace', '$', ':5044') | list }}
+    filebeat_logstash_hosts: "{{ groups['logstash_servers'] | default(['logstash1.example.com']) | map('regex_replace', '$', ':5044') | list }}"
 
     filebeat_global_tags:
       datacenter: "{{ datacenter_name | default('dc1') }}"
@@ -29,7 +29,7 @@
       team: infrastructure
 
   roles:
-    - monitoring_observability.filebeat
+    - filebeat
 
   tags:
     - monitoring

--- a/src/roles/monitoring_observability/filebeat/examples/multi-environment.yml
+++ b/src/roles/monitoring_observability/filebeat/examples/multi-environment.yml
@@ -2,7 +2,7 @@
 # Multi-environment Filebeat deployment
 - name: Deploy Filebeat across multiple environments
   hosts: all
-  become: yes
+  become: true
   vars:
     # Environment-specific configuration
     filebeat_environment: "{{ env_name | default('production') }}"
@@ -74,7 +74,7 @@
       cluster: "{{ cluster_name | default('default') }}"
 
   roles:
-    - monitoring_observability.filebeat
+    - filebeat
 
   tags:
     - monitoring

--- a/src/roles/monitoring_observability/filebeat/examples/security-deployment.yml
+++ b/src/roles/monitoring_observability/filebeat/examples/security-deployment.yml
@@ -2,7 +2,7 @@
 # Security-focused Filebeat deployment
 - name: Deploy Filebeat for security monitoring
   hosts: security_servers
-  become: yes
+  become: true
   vars:
     # Security-focused inputs
     filebeat_inputs:
@@ -102,7 +102,7 @@
     filebeat_config_validate_before_restart: true
 
   roles:
-    - monitoring_observability.filebeat
+    - filebeat
 
   tags:
     - monitoring

--- a/src/roles/monitoring_observability/filebeat/handlers/main.yml
+++ b/src/roles/monitoring_observability/filebeat/handlers/main.yml
@@ -8,8 +8,8 @@
 - name: Validate filebeat after restart
   ansible.builtin.command:
     cmd: filebeat test config -c {{ filebeat_config_file }}
-  register: post_restart_validation
-  failed_when: post_restart_validation.rc != 0
+  register: filebeat_post_restart_validation
+  failed_when: filebeat_post_restart_validation.rc != 0
   changed_when: false
   listen: restart filebeat
 

--- a/src/roles/monitoring_observability/filebeat/molecule/elasticsearch/converge.yml
+++ b/src/roles/monitoring_observability/filebeat/molecule/elasticsearch/converge.yml
@@ -3,4 +3,4 @@
   hosts: all
   become: true
   roles:
-    - role: monitoring_observability.filebeat
+    - role: filebeat

--- a/src/roles/monitoring_observability/filebeat/molecule/proxmox/molecule.yml
+++ b/src/roles/monitoring_observability/filebeat/molecule/proxmox/molecule.yml
@@ -29,14 +29,14 @@ provisioner:
         ansible_connection: ssh
         ansible_ssh_pass: molecule123
         ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
-        ansible_become: yes
+        ansible_become: true
         ansible_become_method: sudo
   config_options:
     defaults:
       host_key_checking: false
       stdout_callback: yaml
       bin_ansible_callbacks: true
-      role_name_check: False
+      role_name_check: false
 verifier:
   name: ansible
 scenario:

--- a/src/roles/monitoring_observability/filebeat/molecule/ssl/converge.yml
+++ b/src/roles/monitoring_observability/filebeat/molecule/ssl/converge.yml
@@ -3,4 +3,4 @@
   hosts: all
   become: true
   roles:
-    - role: monitoring_observability.filebeat
+    - role: filebeat

--- a/src/roles/monitoring_observability/filebeat/tasks/backup.yml
+++ b/src/roles/monitoring_observability/filebeat/tasks/backup.yml
@@ -3,7 +3,7 @@
 - name: Check if existing configuration exists
   ansible.builtin.stat:
     path: "{{ filebeat_config_file }}"
-  register: existing_config
+  register: filebeat_existing_config
 
 - name: Create timestamped backup of existing configuration
   ansible.builtin.copy:
@@ -13,11 +13,14 @@
     owner: "{{ filebeat_user }}"
     group: "{{ filebeat_group }}"
     mode: '0644'
-  when: existing_config.stat.exists
+  when: filebeat_existing_config.stat.exists
 
 - name: Keep only last 5 backups
   ansible.builtin.shell: |
+    set -o pipefail
     cd {{ filebeat_config_backup_dir }}
     ls -t filebeat.yml.* | tail -n +6 | xargs -r rm
+  args:
+    executable: /bin/bash
   changed_when: false
   failed_when: false

--- a/src/roles/monitoring_observability/filebeat/tasks/config.yml
+++ b/src/roles/monitoring_observability/filebeat/tasks/config.yml
@@ -4,9 +4,9 @@
   ansible.builtin.template:
     src: filebeat.yml.j2
     dest: "{{ filebeat_config_file }}"
-    owner: "{{ filebeat_user }}"
-    group: "{{ filebeat_group }}"
-    mode: '0644'
+    owner: "{{ filebeat_config_file_owner }}"
+    group: "{{ filebeat_config_file_group }}"
+    mode: "{{ filebeat_config_file_mode }}"
     backup: "{{ filebeat_template_backup }}"
   register: filebeat_config_result
   notify: restart filebeat
@@ -14,8 +14,8 @@
 - name: Validate Filebeat configuration
   ansible.builtin.command:
     cmd: filebeat test config -c {{ filebeat_config_file }}
-  register: config_validation
-  failed_when: config_validation.rc != 0
+  register: filebeat_config_validation
+  failed_when: filebeat_config_validation.rc != 0
   changed_when: false
   when: filebeat_config_validate_before_restart
 
@@ -26,8 +26,8 @@
       ansible.builtin.copy:
         src: "{{ filebeat_ssl_certificate }}"
         dest: "{{ filebeat_config_dir }}/filebeat.crt"
-        owner: "{{ filebeat_user }}"
-        group: "{{ filebeat_group }}"
+        owner: "{{ filebeat_config_file_owner }}"
+        group: "{{ filebeat_config_file_group }}"
         mode: '0644'
       when: filebeat_ssl_certificate != ""
 
@@ -35,8 +35,8 @@
       ansible.builtin.copy:
         src: "{{ filebeat_ssl_key }}"
         dest: "{{ filebeat_config_dir }}/filebeat.key"
-        owner: "{{ filebeat_user }}"
-        group: "{{ filebeat_group }}"
+        owner: "{{ filebeat_config_file_owner }}"
+        group: "{{ filebeat_config_file_group }}"
         mode: '0600'
       when: filebeat_ssl_key != ""
 
@@ -44,8 +44,8 @@
       ansible.builtin.copy:
         src: "{{ item }}"
         dest: "{{ filebeat_config_dir }}/ca.crt"
-        owner: "{{ filebeat_user }}"
-        group: "{{ filebeat_group }}"
+        owner: "{{ filebeat_config_file_owner }}"
+        group: "{{ filebeat_config_file_group }}"
         mode: '0644'
       loop: "{{ filebeat_ssl_certificate_authorities }}"
       when: filebeat_ssl_certificate_authorities | length > 0
@@ -53,6 +53,6 @@
 - name: Set file permissions for configuration
   ansible.builtin.file:
     path: "{{ filebeat_config_file }}"
-    owner: "{{ filebeat_user }}"
-    group: "{{ filebeat_group }}"
-    mode: '0644'
+    owner: "{{ filebeat_config_file_owner }}"
+    group: "{{ filebeat_config_file_group }}"
+    mode: "{{ filebeat_config_file_mode }}"

--- a/src/roles/monitoring_observability/filebeat/tasks/health.yml
+++ b/src/roles/monitoring_observability/filebeat/tasks/health.yml
@@ -3,15 +3,15 @@
 - name: Test Filebeat configuration
   ansible.builtin.command:
     cmd: filebeat test config -c {{ filebeat_config_file }}
-  register: config_test
-  failed_when: config_test.rc != 0
+  register: filebeat_config_test
+  failed_when: filebeat_config_test.rc != 0
   changed_when: false
 
 - name: Test output connectivity
   ansible.builtin.command:
     cmd: filebeat test output -c {{ filebeat_config_file }}
-  register: output_test
-  failed_when: output_test.rc != 0
+  register: filebeat_output_test
+  failed_when: filebeat_output_test.rc != 0
   changed_when: false
 
 - name: Check if Filebeat is shipping logs
@@ -26,11 +26,11 @@
 - name: Display health check results
   ansible.builtin.debug:
     msg:
-      - "Configuration test: {{ 'PASSED' if config_test.rc == 0 else 'FAILED' }}"
-      - "Output connectivity test: {{ 'PASSED' if output_test.rc == 0 else 'FAILED' }}"
+      - "Configuration test: {{ 'PASSED' if filebeat_config_test.rc == 0 else 'FAILED' }}"
+      - "Output connectivity test: {{ 'PASSED' if filebeat_output_test.rc == 0 else 'FAILED' }}"
       - "HTTP endpoint status: {{ 'AVAILABLE' if filebeat_stats.status == 200 else 'UNAVAILABLE' }}"
 
 - name: Fail if health checks fail
   ansible.builtin.fail:
     msg: "Filebeat health checks failed"
-  when: config_test.rc != 0 or output_test.rc != 0
+  when: filebeat_config_test.rc != 0 or filebeat_output_test.rc != 0

--- a/src/roles/monitoring_observability/filebeat/tasks/install.yml
+++ b/src/roles/monitoring_observability/filebeat/tasks/install.yml
@@ -9,7 +9,7 @@
   when: ansible_os_family == "Debian"
 
 - name: Install Filebeat (RedHat/CentOS)
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ filebeat_package_name }}"
     state: "{{ filebeat_package_state }}"
   when: ansible_os_family == "RedHat"

--- a/src/roles/monitoring_observability/filebeat/tasks/keystore.yml
+++ b/src/roles/monitoring_observability/filebeat/tasks/keystore.yml
@@ -1,0 +1,31 @@
+---
+- name: Create Filebeat keystore
+  ansible.builtin.command: filebeat keystore create --force
+  args:
+    creates: "{{ filebeat_config_dir }}/filebeat.keystore"
+  when: filebeat_use_keystore
+  become: true
+  notify: restart filebeat
+
+- name: Add Filebeat keystore keys
+  ansible.builtin.shell: |
+    set -o pipefail
+    echo "{{ item.value }}" | filebeat keystore add {{ item.key }} --stdin --force
+  args:
+    executable: /bin/bash
+  loop: "{{ filebeat_keystore_keys | dict2items }}"
+  when:
+    - filebeat_use_keystore
+    - filebeat_keystore_keys | length > 0
+  register: filebeat_keystore_add_result
+  changed_when: filebeat_keystore_add_result.rc == 0
+  no_log: true
+  notify: restart filebeat
+
+- name: Set Filebeat keystore permissions
+  ansible.builtin.file:
+    path: "{{ filebeat_config_dir }}/filebeat.keystore"
+    owner: "{{ filebeat_config_file_owner }}"
+    group: "{{ filebeat_config_file_group }}"
+    mode: '0600'
+  when: filebeat_use_keystore

--- a/src/roles/monitoring_observability/filebeat/tasks/main.yml
+++ b/src/roles/monitoring_observability/filebeat/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+# Shared observability checks
+- name: Assert supported platform
+  ansible.builtin.include_role:
+    name: monitoring_observability.observability_common
+  vars:
+    observability_supported_os_families:
+      - Debian
+      - RedHat
+
 # Load platform-specific variables
 - name: Load platform-specific variables
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
@@ -26,6 +35,13 @@
   tags:
     - filebeat
     - install
+
+# Keystore management
+- name: Manage Filebeat keystore
+  ansible.builtin.include_tasks: keystore.yml
+  tags:
+    - filebeat
+    - security
 
 # Configuration backup
 - name: Backup existing configuration

--- a/src/roles/monitoring_observability/filebeat/tasks/modules.yml
+++ b/src/roles/monitoring_observability/filebeat/tasks/modules.yml
@@ -4,17 +4,17 @@
   ansible.builtin.command:
     cmd: filebeat modules enable {{ item.name }}
   loop: "{{ filebeat_modules_enabled }}"
-  register: module_enable_result
-  changed_when: "'already enabled' not in module_enable_result.stderr"
-  failed_when: module_enable_result.rc != 0 and 'already enabled' not in module_enable_result.stderr
+  register: filebeat_module_enable_result
+  changed_when: "'already enabled' not in filebeat_module_enable_result.stderr"
+  failed_when: filebeat_module_enable_result.rc != 0 and 'already enabled' not in filebeat_module_enable_result.stderr
 
 - name: Disable Filebeat modules
   ansible.builtin.command:
     cmd: filebeat modules disable {{ item }}
   loop: "{{ filebeat_modules_disabled }}"
-  register: module_disable_result
-  changed_when: "'already disabled' not in module_disable_result.stderr"
-  failed_when: module_disable_result.rc != 0 and 'already disabled' not in module_disable_result.stderr
+  register: filebeat_module_disable_result
+  changed_when: "'already disabled' not in filebeat_module_disable_result.stderr"
+  failed_when: filebeat_module_disable_result.rc != 0 and 'already disabled' not in filebeat_module_disable_result.stderr
 
 - name: Configure enabled modules
   ansible.builtin.template:
@@ -30,9 +30,9 @@
 - name: List enabled modules
   ansible.builtin.command:
     cmd: filebeat modules list
-  register: enabled_modules
+  register: filebeat_enabled_modules
   changed_when: false
 
 - name: Display enabled modules
   ansible.builtin.debug:
-    msg: "Enabled modules: {{ enabled_modules.stdout_lines }}"
+    msg: "Enabled modules: {{ filebeat_enabled_modules.stdout_lines }}"

--- a/src/roles/monitoring_observability/filebeat/tasks/monitoring.yml
+++ b/src/roles/monitoring_observability/filebeat/tasks/monitoring.yml
@@ -17,7 +17,10 @@
       http.host: "{{ filebeat_http_host }}"
       http.port: {{ filebeat_http_port }}
     insertafter: EOF
-    create: yes
+    create: true
+    owner: "{{ filebeat_config_file_owner }}"
+    group: "{{ filebeat_config_file_group }}"
+    mode: "{{ filebeat_config_file_mode }}"
   when: filebeat_http_enabled
   notify: restart filebeat
 

--- a/src/roles/monitoring_observability/logstash/tasks/main.yml
+++ b/src/roles/monitoring_observability/logstash/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Ensure supported platform
-  ansible.builtin.assert:
-    that:
-      - ansible_os_family in ["Debian", "RedHat"]
-    fail_msg: >-
-      The monitoring_observability.logstash role currently supports Debian/Ubuntu
-      and RHEL-compatible distributions.
+  ansible.builtin.include_role:
+    name: monitoring_observability.observability_common
+  vars:
+    observability_supported_os_families:
+      - Debian
+      - RedHat
 
 - name: Load platform specific variables
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"

--- a/src/roles/monitoring_observability/observability_common/defaults/main.yml
+++ b/src/roles/monitoring_observability/observability_common/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+observability_supported_os_families:
+  - Debian
+  - RedHat

--- a/src/roles/monitoring_observability/observability_common/meta/main.yml
+++ b/src/roles/monitoring_observability/observability_common/meta/main.yml
@@ -1,13 +1,11 @@
 ---
 galaxy_info:
-  role_name: filebeat
+  role_name: observability_common
   namespace: monitoring_observability
   author: Infrastructure Team
-  description: Install and configure Filebeat for log shipping
-  company: Your Organization
+  description: Shared observability role helpers
   license: MIT
   min_ansible_version: "2.9"
-
   platforms:
     - name: Ubuntu
       versions:
@@ -23,16 +21,4 @@ galaxy_info:
         - "8"
         - "9"
 
-  galaxy_tags:
-    - logging
-    - monitoring
-    - observability
-    - elastic
-    - filebeat
-    - logshipping
-
 dependencies: []
-
-collections:
-  - ansible.posix
-  - community.general

--- a/src/roles/monitoring_observability/observability_common/tasks/main.yml
+++ b/src/roles/monitoring_observability/observability_common/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Assert supported platform
+  ansible.builtin.assert:
+    that:
+      - ansible_os_family in observability_supported_os_families
+    fail_msg: >-
+      This role supports {{ observability_supported_os_families | join(', ') }}.

--- a/src/scripts/create_ansible_inventory.py
+++ b/src/scripts/create_ansible_inventory.py
@@ -15,6 +15,8 @@ try:
 except ImportError:  # pragma: no cover - exercised when psycopg2 is absent
     psycopg2 = None  # type: ignore[assignment]
 
+from scripts.logging_utils import setup_logging
+
 
 @dataclass(frozen=True)
 class ContainerRecord:
@@ -206,18 +208,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=os.environ.get("ANSIBLE_BECOME_PASS"),
         help="Privilege escalation password for generated inventory entries (overrides ANSIBLE_BECOME_PASS).",
     )
+    parser.add_argument(
+        "--log-level",
+        default=os.environ.get("ANSIBLE_SCRIPTS_LOG_LEVEL", "INFO"),
+        help="Logging level (default: INFO).",
+    )
 
     args = parser.parse_args(argv)
+    logger = setup_logging(args.log_level)
 
     output_directory = Path(args.output_directory)
 
     if psycopg2 is None:
-        raise RuntimeError("psycopg2 is required to connect to PostgreSQL. Install it before running the CLI.")
+        logger.error("psycopg2 is required to connect to PostgreSQL. Install it before running the CLI.")
+        return 1
 
     with psycopg2.connect(args.db_conn_str) as connection:  # type: ignore[union-attr]
         rows = fetch_inventory_rows(connection)
 
     generate_inventory(rows, output_directory, args.ansible_user, args.become_pass)
+    logger.info("Inventory files generated in %s", output_directory)
     return 0
 
 

--- a/src/scripts/create_bind_9.py
+++ b/src/scripts/create_bind_9.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import argparse
-import sys
-from ipaddress import ip_address
-from proxmoxer import ProxmoxAPI
+import os
+from typing import Sequence
+
+from scripts.logging_utils import setup_logging
+from scripts.proxmox_client import ProxmoxAuth, collect_dns_records, connect
 
 """Generate a BIND9 zone file populated from a Proxmox cluster.
 
@@ -14,172 +18,45 @@ no usable IP address is advertised. Running the script therefore requires API
 credentials with sufficient privileges to call those endpoints.
 """
 
-# Set up command line argument parsing
-parser = argparse.ArgumentParser(description='Generate a BIND9 domain file using the Proxmox API.')
-parser.add_argument('--host', required=True, help='Proxmox host')
-parser.add_argument('--user', required=True, help='Proxmox user')
-parser.add_argument('--password', required=True, help='Proxmox password')
-parser.add_argument('--domain', required=True, help='Domain name')
-
-# Parse command line arguments
-args = parser.parse_args()
-
-proxmox_host = args.host
-proxmox_user = args.user
-proxmox_password = args.password
-domain = args.domain
-
-# Connect to Proxmox API
-proxmox = ProxmoxAPI(proxmox_host, user=proxmox_user, password=proxmox_password, verify_ssl=False)
-
-# Get list of all nodes
-nodes = proxmox.nodes.get()
-
-bind_file_content = ""
-
 
 def _format_bind_record(hostname, address):
-    """Return a BIND record line for the provided hostname and IP address."""
-
     record_type = "AAAA" if address.version == 6 else "A"
     return f"{hostname} IN {record_type} {address}"
 
 
-def _first_non_loopback_guest_ip(agent_network):
-    """Return the first non-loopback IP address reported by the guest agent."""
-
-    if not isinstance(agent_network, dict):
-        return None
-
-    result = agent_network.get('result', {})
-    if not isinstance(result, dict):
-        return None
-
-    for interface, data in result.items():
-        if not isinstance(data, dict):
-            continue
-
-        addresses = data.get('ip-addresses', [])
-        if not isinstance(addresses, list):
-            continue
-
-        for address in addresses:
-            if not isinstance(address, dict):
-                continue
-
-            ip_value = address.get('ip-address')
-            if not ip_value:
-                continue
-
-            try:
-                parsed = ip_address(ip_value)
-            except ValueError:
-                continue
-
-            if parsed.is_loopback:
-                continue
-
-            return parsed
-
-    return None
+def build_bind_records(proxmox, logger) -> str:
+    lines = []
+    for hostname, address in collect_dns_records(proxmox, logger):
+        lines.append(_format_bind_record(hostname, address))
+    return "\n".join(lines) + ("\n" if lines else "")
 
 
-def _first_non_loopback_lxc_ip(status):
-    """Return the first non-loopback IP address reported for an LXC container."""
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate a BIND9 domain file using the Proxmox API.")
+    parser.add_argument("--host", required=True, help="Proxmox host")
+    parser.add_argument("--user", required=True, help="Proxmox user")
+    parser.add_argument("--password", required=True, help="Proxmox password")
+    parser.add_argument("--domain", required=True, help="Domain name")
+    parser.add_argument(
+        "--log-level",
+        default=os.environ.get("ANSIBLE_SCRIPTS_LOG_LEVEL", "INFO"),
+        help="Logging level (default: INFO).",
+    )
+    args = parser.parse_args(argv)
 
-    if not isinstance(status, dict):
-        return None
+    logger = setup_logging(args.log_level)
+    auth = ProxmoxAuth(host=args.host, user=args.user, password=args.password)
+    proxmox = connect(auth)
 
-    candidates = []
+    bind_file_content = build_bind_records(proxmox, logger)
 
-    def _extend_from_field(field):
-        if isinstance(field, str):
-            candidates.extend(part.strip() for part in field.split() if part.strip())
-        elif isinstance(field, dict):
-            ip_value = field.get('ip') or field.get('address')
-            if ip_value:
-                candidates.append(ip_value)
-        elif isinstance(field, list):
-            for item in field:
-                _extend_from_field(item)
+    output_path = f"db.{args.domain}"
+    with open(output_path, "w", encoding="utf-8") as bind_file:
+        bind_file.write(bind_file_content)
 
-    _extend_from_field(status.get('ip'))
-    _extend_from_field(status.get('ip6'))
-
-    for candidate in candidates:
-        ip_value = candidate.split('/', 1)[0]
-        try:
-            parsed = ip_address(ip_value)
-        except ValueError:
-            continue
-
-        if parsed.is_loopback:
-            continue
-
-        return parsed
-
-    return None
+    logger.info("DNS file for domain %s was successfully created at %s.", args.domain, output_path)
+    return 0
 
 
-for node in nodes:
-    node_ip = node['ip']
-    node_name = node['node']
-
-    try:
-        node_address = ip_address(node_ip)
-    except ValueError:
-        print(
-            f"Warning: skipping node '{node_name}' - invalid IP address '{node_ip}'",
-            file=sys.stderr,
-        )
-        node_address = None
-
-    if node_address:
-        # Append node to BIND9 file content
-        bind_file_content += _format_bind_record(node_name, node_address) + "\n"
-
-    # Get list of all QEMU/KVM VMs
-    vms_qemu = proxmox.nodes(node['node']).qemu.get()
-    for vm in vms_qemu:
-        hostname = vm['name']
-        try:
-            agent_network = proxmox.nodes(node['node']).qemu(vm['vmid']).agent.network_get()
-        except Exception as exc:  # noqa: BLE001 - proxmoxer may raise varied exceptions
-            print(
-                f"Warning: skipping VM '{hostname}' (vmid {vm['vmid']}) on node '{node_name}' - guest agent query failed: {exc}",
-                file=sys.stderr,
-            )
-            continue
-
-        ip_address_obj = _first_non_loopback_guest_ip(agent_network)
-        if not ip_address_obj:
-            print(
-                f"Warning: skipping VM '{hostname}' (vmid {vm['vmid']}) on node '{node_name}' - no non-loopback IP reported by guest agent",
-                file=sys.stderr,
-            )
-            continue
-
-        # Append VM to BIND9 file content
-        bind_file_content += _format_bind_record(hostname, ip_address_obj) + "\n"
-
-    # Get list of all LXC containers
-    vms_lxc = proxmox.nodes(node['node']).lxc.get()
-    for vm in vms_lxc:
-        hostname = vm['name']
-        status = proxmox.nodes(node['node']).lxc(vm['vmid']).status.current.get()
-        ip_address_obj = _first_non_loopback_lxc_ip(status)
-        if not ip_address_obj:
-            print(
-                f"Warning: skipping LXC '{hostname}' (vmid {vm['vmid']}) on node '{node_name}' - unable to determine non-loopback IP",
-                file=sys.stderr,
-            )
-            continue
-
-        # Append VM to BIND9 file content
-        bind_file_content += _format_bind_record(hostname, ip_address_obj) + "\n"
-
-# Write to BIND9 file
-with open("db." + domain, "w") as f:
-    f.write(bind_file_content)
-
-print(f"DNS file for domain {domain} was successfully created.")
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scripts/inventory_cli.py
+++ b/src/scripts/inventory_cli.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Sequence
+
+from scripts.create_ansible_inventory import fetch_inventory_rows, generate_inventory
+from scripts.logging_utils import setup_logging
+from scripts.proxmox_client import ProxmoxAuth, collect_dns_records, connect
+
+
+def _add_log_level(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--log-level",
+        default=os.environ.get("ANSIBLE_SCRIPTS_LOG_LEVEL", "INFO"),
+        help="Logging level (default: INFO).",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Unified inventory tooling CLI.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    db_parser = subparsers.add_parser("db-generate", help="Generate inventories from PostgreSQL.")
+    db_parser.add_argument("--db-conn-str", required=True, help="Database connection string.")
+    db_parser.add_argument("--output-directory", required=True, help="Directory for INI inventories.")
+    db_parser.add_argument(
+        "--ansible-user",
+        default=os.environ.get("ANSIBLE_INVENTORY_USER"),
+        help="SSH user for generated inventory entries.",
+    )
+    db_parser.add_argument(
+        "--become-pass",
+        default=os.environ.get("ANSIBLE_BECOME_PASS"),
+        help="Privilege escalation password for generated inventory entries.",
+    )
+    _add_log_level(db_parser)
+
+    proxmox_parser = subparsers.add_parser("proxmox-test", help="Validate Proxmox access and summarize nodes/VMs.")
+    proxmox_parser.add_argument("--host", required=True, help="Proxmox host")
+    proxmox_parser.add_argument("--user", required=True, help="Proxmox user")
+    proxmox_parser.add_argument("--password", required=True, help="Proxmox password")
+    proxmox_parser.add_argument("--verify-ssl", action="store_true", help="Enable SSL verification")
+    _add_log_level(proxmox_parser)
+
+    return parser
+
+
+def _run_db_generate(args: argparse.Namespace) -> int:
+    logger = setup_logging(args.log_level)
+    try:
+        import psycopg2  # pylint: disable=import-outside-toplevel
+    except ImportError as exc:  # pragma: no cover - exercised when psycopg2 is absent
+        logger.error("psycopg2 is required to connect to PostgreSQL: %s", exc)
+        return 1
+
+    output_directory = Path(args.output_directory)
+
+    with psycopg2.connect(args.db_conn_str) as connection:
+        rows = fetch_inventory_rows(connection)
+
+    generate_inventory(rows, output_directory, args.ansible_user, args.become_pass)
+    logger.info("Inventory files generated in %s", output_directory)
+    return 0
+
+
+def _run_proxmox_test(args: argparse.Namespace) -> int:
+    logger = setup_logging(args.log_level)
+    auth = ProxmoxAuth(
+        host=args.host,
+        user=args.user,
+        password=args.password,
+        verify_ssl=args.verify_ssl,
+    )
+    proxmox = connect(auth)
+    records = list(collect_dns_records(proxmox, logger))
+    logger.info("Discovered %s DNS records from Proxmox.", len(records))
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "db-generate":
+        return _run_db_generate(args)
+    if args.command == "proxmox-test":
+        return _run_proxmox_test(args)
+
+    raise ValueError(f"Unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scripts/logging_utils.py
+++ b/src/scripts/logging_utils.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import logging
+
+
+def setup_logging(level: str = "INFO") -> logging.Logger:
+    logging.basicConfig(
+        level=level.upper(),
+        format="%(levelname)s: %(message)s",
+    )
+    return logging.getLogger(__name__)

--- a/src/scripts/proxmox_client.py
+++ b/src/scripts/proxmox_client.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from ipaddress import ip_address, IPv4Address, IPv6Address
+from typing import Iterable
+
+from proxmoxer import ProxmoxAPI
+
+IPAddress = IPv4Address | IPv6Address
+
+
+@dataclass(frozen=True)
+class ProxmoxAuth:
+    host: str
+    user: str
+    password: str
+    verify_ssl: bool = False
+
+
+def connect(auth: ProxmoxAuth):
+    return ProxmoxAPI(auth.host, user=auth.user, password=auth.password, verify_ssl=auth.verify_ssl)
+
+
+def first_non_loopback_guest_ip(agent_network: dict) -> IPAddress | None:
+    if not isinstance(agent_network, dict):
+        return None
+
+    result = agent_network.get("result", {})
+    if not isinstance(result, dict):
+        return None
+
+    for data in result.values():
+        if not isinstance(data, dict):
+            continue
+
+        addresses = data.get("ip-addresses", [])
+        if not isinstance(addresses, list):
+            continue
+
+        for address in addresses:
+            if not isinstance(address, dict):
+                continue
+
+            ip_value = address.get("ip-address")
+            if not ip_value:
+                continue
+
+            try:
+                parsed = ip_address(ip_value)
+            except ValueError:
+                continue
+
+            if parsed.is_loopback:
+                continue
+
+            return parsed
+
+    return None
+
+
+def first_non_loopback_lxc_ip(status: dict) -> IPAddress | None:
+    if not isinstance(status, dict):
+        return None
+
+    candidates: list[str] = []
+
+    def extend_from_field(field):
+        if isinstance(field, str):
+            candidates.extend(part.strip() for part in field.split() if part.strip())
+        elif isinstance(field, dict):
+            ip_value = field.get("ip") or field.get("address")
+            if ip_value:
+                candidates.append(ip_value)
+        elif isinstance(field, list):
+            for item in field:
+                extend_from_field(item)
+
+    extend_from_field(status.get("ip"))
+    extend_from_field(status.get("ip6"))
+
+    for candidate in candidates:
+        ip_value = candidate.split("/", 1)[0]
+        try:
+            parsed = ip_address(ip_value)
+        except ValueError:
+            continue
+
+        if parsed.is_loopback:
+            continue
+
+        return parsed
+
+    return None
+
+
+def collect_dns_records(proxmox, logger: logging.Logger) -> Iterable[tuple[str, IPAddress]]:
+    for node in proxmox.nodes.get():
+        node_ip = node.get("ip")
+        node_name = node.get("node")
+
+        try:
+            node_address = ip_address(node_ip)
+        except ValueError:
+            logger.warning("Skipping node '%s' - invalid IP address '%s'", node_name, node_ip)
+            node_address = None
+
+        if node_address:
+            yield node_name, node_address
+
+        vms_qemu = proxmox.nodes(node_name).qemu.get()
+        for vm in vms_qemu:
+            hostname = vm.get("name")
+            try:
+                agent_network = proxmox.nodes(node_name).qemu(vm["vmid"]).agent.network_get()
+            except Exception as exc:  # noqa: BLE001 - proxmoxer may raise varied exceptions
+                logger.warning(
+                    "Skipping VM '%s' (vmid %s) on node '%s' - guest agent query failed: %s",
+                    hostname,
+                    vm.get("vmid"),
+                    node_name,
+                    exc,
+                )
+                continue
+
+            ip_address_obj = first_non_loopback_guest_ip(agent_network)
+            if not ip_address_obj:
+                logger.warning(
+                    "Skipping VM '%s' (vmid %s) on node '%s' - no non-loopback IP reported by guest agent",
+                    hostname,
+                    vm.get("vmid"),
+                    node_name,
+                )
+                continue
+
+            yield hostname, ip_address_obj
+
+        vms_lxc = proxmox.nodes(node_name).lxc.get()
+        for vm in vms_lxc:
+            hostname = vm.get("name")
+            status = proxmox.nodes(node_name).lxc(vm["vmid"]).status.current.get()
+            ip_address_obj = first_non_loopback_lxc_ip(status)
+            if not ip_address_obj:
+                logger.warning(
+                    "Skipping LXC '%s' (vmid %s) on node '%s' - unable to determine non-loopback IP",
+                    hostname,
+                    vm.get("vmid"),
+                    node_name,
+                )
+                continue
+
+            yield hostname, ip_address_obj

--- a/src/scripts/setup-proxmox-dynamic-inventory.ps1
+++ b/src/scripts/setup-proxmox-dynamic-inventory.ps1
@@ -107,6 +107,13 @@ Write-Host "To test your configuration, run:" -ForegroundColor White
 Write-Host "python -c `"import yaml; print('YAML parser OK')`"" -ForegroundColor Cyan
 Write-Host ""
 
+# Optional: test Proxmox API access via unified CLI
+if ($ProxmoxUrl -ne "https://your-proxmox-server:8006" -and $ProxmoxUser -ne "ansible@pve" -and $ProxmoxPassword -ne "") {
+    Write-Host "`nOptional: testing Proxmox API access with unified CLI..." -ForegroundColor Yellow
+    Write-Host "Running: python src/scripts/inventory_cli.py proxmox-test --host $ProxmoxUrl --user $ProxmoxUser --password ******" -ForegroundColor Cyan
+    python src/scripts/inventory_cli.py proxmox-test --host $ProxmoxUrl --user $ProxmoxUser --password $ProxmoxPassword
+}
+
 # Step 8: Usage instructions
 Write-Host "`n=== Next Steps ===" -ForegroundColor Green
 Write-Host "1. Download and install the community.general and community.proxmox collections manually (see above)" -ForegroundColor White

--- a/src/scripts/test-proxmox-inventory.ps1
+++ b/src/scripts/test-proxmox-inventory.ps1
@@ -9,10 +9,32 @@ param(
     [switch]$UseVault,
     
     [Parameter(Mandatory=$false)]
-    [switch]$ShowGraph
+    [switch]$ShowGraph,
+
+    [Parameter(Mandatory=$false)]
+    [switch]$UseCli,
+
+    [Parameter(Mandatory=$false)]
+    [string]$ProxmoxHost = $env:PROXMOX_HOST,
+
+    [Parameter(Mandatory=$false)]
+    [string]$ProxmoxUser = $env:PROXMOX_USER,
+
+    [Parameter(Mandatory=$false)]
+    [string]$ProxmoxPassword = $env:PROXMOX_PASSWORD
 )
 
 Write-Host "Testing Proxmox Dynamic Inventory..." -ForegroundColor Green
+
+if ($UseCli) {
+    if (-not $ProxmoxHost -or -not $ProxmoxUser -or -not $ProxmoxPassword) {
+        Write-Host "Missing Proxmox CLI credentials. Set PROXMOX_HOST/USER/PASSWORD or pass parameters." -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Running unified CLI Proxmox test..." -ForegroundColor Cyan
+    python src/scripts/inventory_cli.py proxmox-test --host $ProxmoxHost --user $ProxmoxUser --password $ProxmoxPassword
+}
 
 # Change to src directory
 Set-Location -Path "src"


### PR DESCRIPTION
### Motivation
- Resolve `ansible-lint` failures and harden the Filebeat role by making task behavior deterministic and safer. 
- Add explicit keystore management and configuration ownership/mode controls to improve secret handling and operational correctness. 
- Consolidate and standardize inventory and Proxmox helper code with logging to make tooling easier to reuse and debug.

### Description
- Normalize and harden Filebeat tasks by standardizing `register` names, using `set -o pipefail` with `args.executable: /bin/bash` for shell actions, adding `filebeat_config_file_owner`/`filebeat_config_file_group`/`filebeat_config_file_mode`, switching EL install to `ansible.builtin.dnf`, and fixing metadata tags (`logshipping`).
- Add keystore management via `tasks/keystore.yml` and include it from `tasks/main.yml`, plus adjust backup, config, modules, monitoring, and handler tasks to use the new register names and ownership/mode variables.
- Introduce a shared `monitoring_observability.observability_common` role with platform assertion and wire it into the `filebeat` and `logstash` flows to centralize supported-OS checks.
- Add and refactor CLI and Proxmox helpers by introducing `src/scripts/logging_utils.py`, `src/scripts/proxmox_client.py`, and `src/scripts/inventory_cli.py`, and update `create_bind_9.py` and `create_ansible_inventory.py` to use those helpers and logging; update PowerShell helpers to optionally invoke the unified CLI.

### Testing
- Ran unit tests with `python -m pytest tests/test_create_ansible_inventory.py` and they all succeeded (`3 passed`).
- Ran `ansible-lint` against the Filebeat role with `ansible-lint src/roles/monitoring_observability/filebeat -p` and the role passed with no failures after the fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d20d2b7d0832abdfa2c6ae4295bab)