### PR TITLE
Add TrueNAS SCALE VM creation role

### DIFF
--- a/src/group_vars/truenas_vms.yml
+++ b/src/group_vars/truenas_vms.yml
@@ -1,0 +1,29 @@
+---
+truenas_vm_api_url: "https://truenas.example"
+truenas_vm_api_key: "{{ vault_truenas_api_key }}"
+truenas_vm_name: "web-01"
+truenas_vm_description: "Web server"
+truenas_vm_memory_mib: 4096
+truenas_vm_vcpus: 2
+truenas_vm_os_disk:
+  pool: "apps"
+  size: "40G"
+truenas_vm_data_disks:
+  - pool: "data"
+    size: "200G"
+truenas_vm_networks:
+  - bridge: "br0"
+truenas_vm_cloud_init:
+  user_data: |
+    #cloud-config
+    users:
+      - name: ubuntu
+        sudo: ALL=(ALL) NOPASSWD:ALL
+  network_config: |
+    version: 2
+    ethernets:
+      eth0:
+        addresses: ["192.168.1.50/24"]
+        gateway4: "192.168.1.1"
+        nameservers:
+          addresses: ["1.1.1.1"]

--- a/src/roles/infrastructure/truenas_vm/README.md
+++ b/src/roles/infrastructure/truenas_vm/README.md
@@ -1,0 +1,72 @@
+# infrastructure.truenas_vm
+
+Creates a TrueNAS SCALE virtual machine via the v2 API using an API key. The role is idempotent by name (it skips creation if a VM with the same name already exists).
+
+## Variables
+- truenas_vm_api_url: '' — base URL to the TrueNAS API (e.g. https://truenas.example)
+- truenas_vm_api_key: '' — API key for TrueNAS
+- truenas_vm_validate_certs: true — validate TLS certs
+- truenas_vm_validate_only: false — when true, only validates inputs (no API calls)
+- truenas_vm_name: '' — VM name (required)
+- truenas_vm_description: ''
+- truenas_vm_time: 'UTC'
+- truenas_vm_autostart: false
+- truenas_vm_bootloader: 'UEFI'
+- truenas_vm_cpu_mode: 'HOST-PASSTHROUGH'
+- truenas_vm_vcpus: 1
+- truenas_vm_cores: 1
+- truenas_vm_threads: 1
+- truenas_vm_memory_mib: 1024
+- truenas_vm_disk_bus: 'VIRTIO'
+- truenas_vm_nic_type: 'VIRTIO'
+- truenas_vm_os_disk: { pool: 'apps', size: '20G', zvol_name: '' }
+- truenas_vm_data_disks: [] — list of additional disks (pool defaults to data)
+- truenas_vm_networks: [] — list of NICs with bridge, mac, mtu
+- truenas_vm_iso_path: '' — ISO path already present on TrueNAS
+- truenas_vm_cloud_init: {} — user_data/meta_data/network_config strings
+- truenas_vm_additional_devices: [] — list of extra device payloads
+- truenas_vm_start_on_create: true
+- truenas_vm_wait_for_running: true
+- truenas_vm_wait_retries: 30
+- truenas_vm_wait_delay: 10
+
+## Example (group_vars)
+```yaml
+# group_vars/truenas_vms.yml
+truenas_vm_api_url: "https://truenas.example"
+truenas_vm_api_key: "{{ vault_truenas_api_key }}"
+truenas_vm_name: "web-01"
+truenas_vm_description: "Web server"
+truenas_vm_memory_mib: 4096
+truenas_vm_vcpus: 2
+truenas_vm_os_disk:
+  pool: "apps"
+  size: "40G"
+truenas_vm_data_disks:
+  - pool: "data"
+    size: "200G"
+truenas_vm_networks:
+  - bridge: "br0"
+truenas_vm_cloud_init:
+  user_data: |
+    #cloud-config
+    users:
+      - name: ubuntu
+        sudo: ALL=(ALL) NOPASSWD:ALL
+  network_config: |
+    version: 2
+    ethernets:
+      eth0:
+        addresses: ["192.168.1.50/24"]
+        gateway4: "192.168.1.1"
+        nameservers:
+          addresses: ["1.1.1.1"]
+```
+
+## Example playbook
+```yaml
+- hosts: truenas_api
+  gather_facts: false
+  roles:
+    - role: infrastructure.truenas_vm
+```

--- a/src/roles/infrastructure/truenas_vm/defaults/main.yml
+++ b/src/roles/infrastructure/truenas_vm/defaults/main.yml
@@ -1,0 +1,64 @@
+---
+# Default variables for infrastructure.truenas_vm
+truenas_vm_api_url: ''
+truenas_vm_api_key: ''
+truenas_vm_validate_certs: true
+truenas_vm_validate_only: false
+
+truenas_vm_name: ''
+truenas_vm_description: ''
+truenas_vm_time: 'UTC'
+truenas_vm_autostart: false
+truenas_vm_bootloader: 'UEFI'
+truenas_vm_cpu_mode: 'HOST-PASSTHROUGH'
+truenas_vm_vcpus: 1
+truenas_vm_cores: 1
+truenas_vm_threads: 1
+truenas_vm_memory_mib: 1024
+
+truenas_vm_disk_bus: 'VIRTIO'
+truenas_vm_nic_type: 'VIRTIO'
+
+truenas_vm_os_disk:
+  pool: 'apps'
+  size: '20G'
+  zvol_name: ''
+
+truenas_vm_data_disks: []
+# Example:
+#   - pool: 'data'
+#     size: '100G'
+#     zvol_name: 'vm-data-1'
+
+truenas_vm_networks: []
+# Example:
+#   - bridge: 'br0'
+#     mac: '52:54:00:11:22:33'
+#     mtu: 1500
+
+truenas_vm_iso_path: ''
+
+truenas_vm_cloud_init: {}
+# Example:
+#   user_data: |
+#     #cloud-config
+#     users:
+#       - name: ubuntu
+#   meta_data: |
+#     instance-id: myvm
+#     local-hostname: myvm
+#   network_config: |
+#     version: 2
+#     ethernets:
+#       eth0:
+#         addresses: ["192.168.1.50/24"]
+#         gateway4: "192.168.1.1"
+#         nameservers:
+#           addresses: ["1.1.1.1"]
+
+truenas_vm_additional_devices: []
+
+truenas_vm_start_on_create: true
+truenas_vm_wait_for_running: true
+truenas_vm_wait_retries: 30
+truenas_vm_wait_delay: 10

--- a/src/roles/infrastructure/truenas_vm/meta/main.yml
+++ b/src/roles/infrastructure/truenas_vm/meta/main.yml
@@ -1,0 +1,13 @@
+---
+dependencies: []
+
+galaxy_info:
+  author: your_name
+  description: Create TrueNAS SCALE virtual machines
+  license: MIT
+  min_ansible_version: '2.12'
+  platforms:
+    - name: Debian
+      versions: ['bullseye', 'bookworm']
+    - name: Ubuntu
+      versions: ['focal', 'jammy']

--- a/src/roles/infrastructure/truenas_vm/molecule/proxmox/converge.yml
+++ b/src/roles/infrastructure/truenas_vm/molecule/proxmox/converge.yml
@@ -1,0 +1,20 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include truenas_vm role
+      ansible.builtin.include_role:
+        name: truenas_vm
+      vars:
+        truenas_vm_api_url: "https://truenas.example"
+        truenas_vm_api_key: "test-api-key"
+        truenas_vm_name: "molecule-vm"
+        truenas_vm_validate_only: true
+        truenas_vm_networks:
+          - bridge: "br0"
+        truenas_vm_data_disks:
+          - pool: "data"
+            size: "10G"
+        truenas_vm_cloud_init:
+          user_data: "#cloud-config"

--- a/src/roles/infrastructure/truenas_vm/molecule/proxmox/molecule.yml
+++ b/src/roles/infrastructure/truenas_vm/molecule/proxmox/molecule.yml
@@ -1,0 +1,58 @@
+---
+dependency:
+  name: galaxy
+  enabled: false
+driver:
+  name: default
+  options:
+    managed: false
+    ansible_connection_options:
+      ansible_connection: ssh
+platforms:
+  - name: truenas-vm-test-instance
+    groups:
+      - test_instances
+      - truenas_vm_test
+provisioner:
+  name: ansible
+  playbooks:
+    create: /ansible/src/molecule/proxmox/create.yml
+    prepare: /ansible/src/molecule/proxmox/prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+    destroy: /ansible/src/molecule/proxmox/destroy.yml
+  env:
+    ANSIBLE_ROLES_PATH: "/ansible/src/roles:/ansible/src/roles/infrastructure:/ansible/src/roles/data_analytics:/ansible/src/roles/data_systems:/ansible/src/roles/devops_cicd:/ansible/src/roles/load_balancing_ha:/ansible/src/roles/monitoring_observability:/ansible/src/roles/networking:/ansible/src/roles/operations_management:/ansible/src/roles/security_identity"
+  inventory:
+    host_vars:
+      truenas-vm-test-instance:
+                ansible_host: "{{ lookup('env', 'CONTAINER_IP') | default('10.80.0.200') }}"
+                ansible_user: molecule
+                ansible_connection: ssh
+                ansible_ssh_pass: "{{ lookup('env', 'CONTAINER_PASSWORD') | default('molecule123') }}"
+                ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+                ansible_become: true
+                ansible_become_method: sudo
+  config_options:
+    defaults:
+      host_key_checking: false
+      stdout_callback: yaml
+      bin_ansible_callbacks: true
+      role_name_check: False
+verifier:
+  name: ansible
+scenario:
+  name: proxmox
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/src/roles/infrastructure/truenas_vm/molecule/proxmox/prepare.yml
+++ b/src/roles/infrastructure/truenas_vm/molecule/proxmox/prepare.yml
@@ -1,0 +1,5 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks: []

--- a/src/roles/infrastructure/truenas_vm/molecule/proxmox/verify.yml
+++ b/src/roles/infrastructure/truenas_vm/molecule/proxmox/verify.yml
@@ -1,0 +1,11 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Example assertion
+      ansible.builtin.assert:
+        that:
+          - true
+        success_msg: "Role truenas_vm verification passed"
+        fail_msg: "Role truenas_vm verification failed"

--- a/src/roles/infrastructure/truenas_vm/tasks/main.yml
+++ b/src/roles/infrastructure/truenas_vm/tasks/main.yml
@@ -1,0 +1,234 @@
+---
+- name: Validate required inputs
+  ansible.builtin.assert:
+    that:
+      - truenas_vm_api_url | length > 0
+      - truenas_vm_api_key | length > 0
+      - truenas_vm_name | length > 0
+    fail_msg: >-
+      truenas_vm_api_url, truenas_vm_api_key, and truenas_vm_name are required.
+
+- name: Stop after validation when requested
+  ansible.builtin.debug:
+    msg: "Validation-only mode enabled; skipping API calls."
+  when: truenas_vm_validate_only
+
+- name: Build API headers
+  ansible.builtin.set_fact:
+    truenas_vm_api_headers:
+      Authorization: "Bearer {{ truenas_vm_api_key }}"
+      Content-Type: "application/json"
+  when: not truenas_vm_validate_only
+
+- name: Fetch existing VMs
+  ansible.builtin.uri:
+    url: "{{ truenas_vm_api_url }}/api/v2.0/vm"
+    method: GET
+    headers: "{{ truenas_vm_api_headers }}"
+    validate_certs: "{{ truenas_vm_validate_certs }}"
+    return_content: true
+  register: truenas_vm_list
+  when: not truenas_vm_validate_only
+
+- name: Select existing VM by name
+  ansible.builtin.set_fact:
+    truenas_vm_existing: >-
+      {{ (truenas_vm_list.json | default([]))
+         | selectattr('name', 'equalto', truenas_vm_name)
+         | list
+         | first
+         | default({}) }}
+  when: not truenas_vm_validate_only
+
+- name: Set existing VM ID
+  ansible.builtin.set_fact:
+    truenas_vm_id: "{{ truenas_vm_existing.id }}"
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length > 0
+
+- name: Build create payload
+  ansible.builtin.set_fact:
+    truenas_vm_payload:
+      name: "{{ truenas_vm_name }}"
+      description: "{{ truenas_vm_description }}"
+      vcpus: "{{ truenas_vm_vcpus }}"
+      cores: "{{ truenas_vm_cores }}"
+      threads: "{{ truenas_vm_threads }}"
+      memory: "{{ truenas_vm_memory_mib }}"
+      autostart: "{{ truenas_vm_autostart }}"
+      time: "{{ truenas_vm_time }}"
+      bootloader: "{{ truenas_vm_bootloader }}"
+      cpu_mode: "{{ truenas_vm_cpu_mode }}"
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length == 0
+
+- name: Create VM
+  ansible.builtin.uri:
+    url: "{{ truenas_vm_api_url }}/api/v2.0/vm"
+    method: POST
+    headers: "{{ truenas_vm_api_headers }}"
+    validate_certs: "{{ truenas_vm_validate_certs }}"
+    body_format: json
+    body: "{{ truenas_vm_payload }}"
+    status_code: [200, 201]
+    return_content: true
+  register: truenas_vm_create
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length == 0
+
+- name: Capture created VM ID
+  ansible.builtin.set_fact:
+    truenas_vm_id: "{{ truenas_vm_create.json.id }}"
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length == 0
+
+- name: Build device list
+  ansible.builtin.set_fact:
+    truenas_vm_devices: []
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length == 0
+
+- name: Add OS disk device
+  ansible.builtin.set_fact:
+    truenas_vm_devices: "{{ truenas_vm_devices + [os_disk_device] }}"
+  vars:
+    os_disk_name: "{{ truenas_vm_os_disk.zvol_name | default(truenas_vm_name ~ '-os') }}"
+    os_disk_device:
+      dtype: DISK
+      attributes:
+        type: "{{ truenas_vm_disk_bus }}"
+        create_zvol: true
+        zvol_name: "{{ truenas_vm_os_disk.pool }}/{{ os_disk_name }}"
+        zvol_volsize: "{{ truenas_vm_os_disk.size }}"
+        path: "/dev/zvol/{{ truenas_vm_os_disk.pool }}/{{ os_disk_name }}"
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length == 0
+    - truenas_vm_os_disk is defined
+    - truenas_vm_os_disk.size | length > 0
+
+- name: Add data disk devices
+  ansible.builtin.set_fact:
+    truenas_vm_devices: "{{ truenas_vm_devices + [data_disk_device] }}"
+  vars:
+    data_disk_name: "{{ item.zvol_name | default(truenas_vm_name ~ '-data-' ~ index) }}"
+    data_disk_device:
+      dtype: DISK
+      attributes:
+        type: "{{ truenas_vm_disk_bus }}"
+        create_zvol: true
+        zvol_name: "{{ item.pool | default('data') }}/{{ data_disk_name }}"
+        zvol_volsize: "{{ item.size }}"
+        path: "/dev/zvol/{{ item.pool | default('data') }}/{{ data_disk_name }}"
+  loop: "{{ truenas_vm_data_disks }}"
+  loop_control:
+    index_var: index
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length == 0
+    - truenas_vm_data_disks | length > 0
+
+- name: Add network devices
+  ansible.builtin.set_fact:
+    truenas_vm_devices: "{{ truenas_vm_devices + [network_device] }}"
+  vars:
+    network_attributes: >-
+      {{ {'type': truenas_vm_nic_type, 'nic_attach': item.bridge}
+         | combine(item.mac is defined | ternary({'mac': item.mac}, {}))
+         | combine(item.mtu is defined | ternary({'mtu': item.mtu}, {})) }}
+    network_device:
+      dtype: NIC
+      attributes: "{{ network_attributes }}"
+  loop: "{{ truenas_vm_networks }}"
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length == 0
+    - truenas_vm_networks | length > 0
+
+- name: Add ISO device
+  ansible.builtin.set_fact:
+    truenas_vm_devices: "{{ truenas_vm_devices + [iso_device] }}"
+  vars:
+    iso_device:
+      dtype: CDROM
+      attributes:
+        path: "{{ truenas_vm_iso_path }}"
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length == 0
+    - truenas_vm_iso_path | length > 0
+
+- name: Add cloud-init device
+  ansible.builtin.set_fact:
+    truenas_vm_devices: "{{ truenas_vm_devices + [cloudinit_device] }}"
+  vars:
+    cloudinit_device:
+      dtype: CLOUDINIT
+      attributes:
+        user_data: "{{ truenas_vm_cloud_init.user_data | default('') }}"
+        meta_data: "{{ truenas_vm_cloud_init.meta_data | default('') }}"
+        network_config: "{{ truenas_vm_cloud_init.network_config | default('') }}"
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length == 0
+    - truenas_vm_cloud_init | length > 0
+
+- name: Add additional devices
+  ansible.builtin.set_fact:
+    truenas_vm_devices: "{{ truenas_vm_devices + truenas_vm_additional_devices }}"
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length == 0
+    - truenas_vm_additional_devices | length > 0
+
+- name: Create VM devices
+  ansible.builtin.uri:
+    url: "{{ truenas_vm_api_url }}/api/v2.0/vm/device"
+    method: POST
+    headers: "{{ truenas_vm_api_headers }}"
+    validate_certs: "{{ truenas_vm_validate_certs }}"
+    body_format: json
+    body:
+      vm: "{{ truenas_vm_id }}"
+      dtype: "{{ item.dtype }}"
+      attributes: "{{ item.attributes }}"
+    status_code: [200, 201]
+  loop: "{{ truenas_vm_devices }}"
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length == 0
+    - truenas_vm_devices | length > 0
+
+- name: Start VM
+  ansible.builtin.uri:
+    url: "{{ truenas_vm_api_url }}/api/v2.0/vm/id/{{ truenas_vm_id }}/start"
+    method: POST
+    headers: "{{ truenas_vm_api_headers }}"
+    validate_certs: "{{ truenas_vm_validate_certs }}"
+    status_code: [200, 201]
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length == 0
+    - truenas_vm_start_on_create
+
+- name: Wait for VM to be running
+  ansible.builtin.uri:
+    url: "{{ truenas_vm_api_url }}/api/v2.0/vm/id/{{ truenas_vm_id }}"
+    method: GET
+    headers: "{{ truenas_vm_api_headers }}"
+    validate_certs: "{{ truenas_vm_validate_certs }}"
+    return_content: true
+  register: truenas_vm_status
+  retries: "{{ truenas_vm_wait_retries }}"
+  delay: "{{ truenas_vm_wait_delay }}"
+  until: truenas_vm_status.json.state == 'RUNNING'
+  when:
+    - not truenas_vm_validate_only
+    - truenas_vm_existing | length == 0
+    - truenas_vm_start_on_create
+    - truenas_vm_wait_for_running


### PR DESCRIPTION
### Motivation
- Provide an idempotent Ansible role to create TrueNAS SCALE virtual machines via the v2 API using an API key and configurable parameters.
- Make VM attributes configurable (name, CPU, memory, OS/data disks, NICs/bridge/mac/mtu, cloud-init, start/wait options) so the role can be used from `group_vars`. 
- Include a Molecule `proxmox` scenario to enable validation-only CI-style checks of the role without performing destructive changes.

### Description
- Add a new role `infrastructure.truenas_vm` with `defaults/main.yml`, `tasks/main.yml`, `meta/main.yml`, and `README.md` to implement creation logic and document variables and examples. 
- Implement input validation, API header construction, existing-VM lookup (idempotency by `name`), VM create payload, and device creation (OS disk in `apps` pool, optional data disks in `data` pool, ISO, cloud-init) in `tasks/main.yml`. 
- Build NIC attributes with conditional inclusion of `mac` and `mtu` using `combine(...)` so network devices are created as required by `truenas_vm_networks`. 
- Add a Molecule `proxmox` scenario (`molecule.yml`, `converge.yml`, `prepare.yml`, `verify.yml`) and a sample `group_vars/truenas_vms.yml` demonstrating how to pass parameters (including `truenas_vm_api_key`).

### Testing
- Ran `molecule test -s proxmox` which completed syntax validation but the `converge` step failed in this environment due to the removed `community.general.yaml` callback plugin (environment-specific issue), so full converge verification could not complete. 
- The `molecule syntax` stage executed successfully during the Molecule run. 
- Attempted `ansible-lint`, but it did not complete in this environment (timed out / constrained by offline environment warnings). 
- No further automated tests were run in this environment due to Molecule callback incompatibility and linter time constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3d1e2e84832a8d4e1c182b8bffcb)